### PR TITLE
#14 - 버디 일정 서비스 디스커버리 서버에 등록 & 게이트웨이 라우팅

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,9 +6,8 @@
 
   [네이버 코드 컨벤션](./mdSource/naver-code-convention.md)
 
-
 # MicroService
 
 # CommunityService
 
-# BuddyService
+# BuddyService ([버디 서비스](./buddy-service/ReadMe.md))

--- a/buddy-service/ReadMe.md
+++ b/buddy-service/ReadMe.md
@@ -1,55 +1,69 @@
 # BuddyService ( 버디 일정 도메인 )
+
 - 역할 : 사용자들이 버디 이벤트를 주최하고, 참여하며, 관리할 수 있는 기능.
 - 단일 책임 : 일정 생성, 관리, 참가자 관리 및 마감과 같은 이벤트 관련 모든 프로세스를 책임집니다.
-이벤트 데이터를 기반으로 사용자에게 맞춤형 이벤트를 추천한다.
-
- 
+  이벤트 데이터를 기반으로 사용자에게 맞춤형 이벤트를 추천한다.
 
 ## 비즈니스 인터페이스
-### Query
-  - 버디 일정 이벤트 조회 하기 ( 'searchBuddyEvents' )
-    > GET buddy-service/v1/buddyEvents
-  - 내가 모집 중인 버디 일정 조회 하기 ( 'listMyRecruitingEvents' )
-    > GET buddy-service/v1/myEvents/recruiting
-  - 버디 일정 참가 신청자 조회 하기 ( 'viewEventApplicants' )
-    > GET buddy-service/v1/buddyEvents/{eventId}/applicants
-  - 사용자 맞춤형 버디 일정 추천 ( 'recommendCustomBuddyEvents' )
-    > GET buddy-service/v1/buddyEvents/recommendations
-### Command
-  - 버디 일정 이벤트 생성 하기 ( 'createBuddyEvent' )
-    > POST buddy-service/v1/buddyEvents
-    - 버디 일정 참가 신청 요청 하기 ( 'requestEventParticipation' )
-    > POST buddy-service/v1/buddyEvents/{eventId}/participations
-  - 버디 일정 이벤트 삭제 하기 ( 'deleteBuddyEvent' )
-    > DELETE buddy-service/v1/buddyEvents/{eventId}
-  - 버디 일정 이벤트 수정 하기 ( 'updateBuddyEvent' )
-    > PUT buddy-service/v1/buddyEvents/{eventId}
 
-## Package Architecture 
+### Query
+
+- 버디 일정 이벤트 조회 하기 ( 'searchBuddyEvents' )
+  > GET buddy-service/v1/buddyEvents
+- 내가 모집 중인 버디 일정 조회 하기 ( 'listMyRecruitingEvents' )
+  > GET buddy-service/v1/myEvents/recruiting
+- 버디 일정 참가 신청자 조회 하기 ( 'viewEventApplicants' )
+  > GET buddy-service/v1/buddyEvents/{eventId}/applicants
+- 사용자 맞춤형 버디 일정 추천 ( 'recommendCustomBuddyEvents' )
+  > GET buddy-service/v1/buddyEvents/recommendations
+
+### Command
+
+- 버디 일정 이벤트 생성 하기 ( 'createBuddyEvent' )
+  > POST buddy-service/v1/buddyEvents
+    - 버디 일정 참가 신청 요청 하기 ( 'requestEventParticipation' )
+  > POST buddy-service/v1/buddyEvents/{eventId}/participations
+- 버디 일정 이벤트 삭제 하기 ( 'deleteBuddyEvent' )
+  > DELETE buddy-service/v1/buddyEvents/{eventId}
+- 버디 일정 이벤트 수정 하기 ( 'updateBuddyEvent' )
+  > PUT buddy-service/v1/buddyEvents/{eventId}
+
+## Package Architecture
+
 ```bash
 ├── com.freediving.buddyservice
 │   ├── adapter
-│   │   ├── in.web
-│   │   │   ├── BuddyEventController.java
-│   │   │   ├── CreateBuddyEventRequest.java
-│   │   │   └── UpdateBuddyEventRequest.java
-│   │   └── out
-│   │       ├── BuddyEventEntity.java
-│   │       ├── BuddyEventRepository.java
-│   │       └── BuddyEventRepositoryAdapter.java
-│   │── application
+│   │   ├── in
+│   │   │   ├── web
+│   │   │   │   ├── v1
+│   │   │   │   │   ├── BuddyEventControllerV1.java
+│   │   │   │   │   ├── CreateBuddyEventRequestV1.java
+│   │   │   │   │   └── UpdateBuddyEventRequestV1.java
+│   │   │   │   ├── v2
+│   │   │   │   │   ├── BuddyEventControllerV2.java
+│   │   │   │   │   ├── CreateBuddyEventRequestV2.java
+│   │   │   │   │   └── UpdateBuddyEventRequestV2.java
+│   │   │   └── out
+│   │   │       ├── BuddyEventEntity.java
+│   │   │       ├── BuddyEventRepository.java
+│   │   │       └── BuddyEventRepositoryAdapter.java
+│   ├── application
 │   │   ├── port
 │   │   │   ├── in
-│   │   │   │   ├── CreateBuddyEventCommand.java
-│   │   │   │   ├── UpdateBuddyEventCommand.java
+│   │   │   │   ├── v1
+│   │   │   │   │   ├── CreateBuddyEventCommandV1.java
+│   │   │   │   │   └── UpdateBuddyEventCommandV1.java
+│   │   │   │   ├── v2
+│   │   │   │   │   ├── CreateBuddyEventCommandV2.java
+│   │   │   │   │   └── UpdateBuddyEventCommandV2.java
 │   │   │   │   └── BuddyEventManagementUseCase.java
 │   │   │   └── out
-│   │   │   │   ├── CreateBuddyEventPort.java
-│   │   │   │   ├── UpdateBuddyEventPort.java
-│   │   │   │   └── BuddyEventManagementPort.java
+│   │   │       ├── CreateBuddyEventPort.java
+│   │   │       ├── UpdateBuddyEventPort.java
+│   │   │       └── BuddyEventManagementPort.java
 │   │   └── service
-│   │           └── out
-│   │               └── BuddyEventService.java
+│   │       └── out
+│   │           └── BuddyEventService.java
 │   └── domain
 │       └── BuddyEvent.java
 └── Dockerfile

--- a/buddy-service/build.gradle
+++ b/buddy-service/build.gradle
@@ -2,16 +2,30 @@ plugins {
     id 'java'
 }
 
-group = 'com.freediving'
+group = 'com.freediving.buddy-service'
+version = '0.0.1'
 
-repositories {
-    mavenCentral()
+// 사용자 정의 속성
+ext {
+    set('springCloudVersion', "2023.0.0")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+//	runtimeOnly 'com.h2database:h2'
 }
+
 
 test {
     useJUnitPlatform()

--- a/buddy-service/src/main/java/com/freediving/Main.java
+++ b/buddy-service/src/main/java/com/freediving/Main.java
@@ -1,7 +1,0 @@
-package com.freediving;
-
-public class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello world!");
-    }
-}

--- a/buddy-service/src/main/java/com/freediving/buddyservice/BuddyServiceApplication.java
+++ b/buddy-service/src/main/java/com/freediving/buddyservice/BuddyServiceApplication.java
@@ -1,0 +1,13 @@
+package com.freediving.buddyservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+@SpringBootApplication
+@EnableDiscoveryClient
+public class BuddyServiceApplication {
+	public static void main(String[] args) {
+		SpringApplication.run(BuddyServiceApplication.class, args);
+	}
+}

--- a/buddy-service/src/main/java/com/freediving/buddyservice/adapter/in/web/v1/HelloControllerV1.java
+++ b/buddy-service/src/main/java/com/freediving/buddyservice/adapter/in/web/v1/HelloControllerV1.java
@@ -1,0 +1,13 @@
+package com.freediving.buddyservice.adapter.in.web.v1;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloControllerV1 {
+
+	@GetMapping("/ping")
+	public String hello() {
+		return "pong";
+	}
+}

--- a/buddy-service/src/main/resources/application-local.yml
+++ b/buddy-service/src/main/resources/application-local.yml
@@ -1,0 +1,20 @@
+server:
+  port: 0 # 랜덤 포트 할당
+
+spring:
+  application:
+    name: buddy-service
+eureka:
+  instance:
+    hostname: localhost
+    #    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+  client:
+    # Eureka 서버 등록
+    register-with-eureka: true
+    # Eureka 서버로부터 인스턴스 정보를 주기적으로 가져오는 기능
+    fetch-registry: true
+    # Eureka 서버 위치 등록
+    service-url:
+      # endpoint 지정
+      defaultZone: http://localhost:8761/eureka

--- a/gateway-service/src/main/resources/application-local.yml
+++ b/gateway-service/src/main/resources/application-local.yml
@@ -24,5 +24,19 @@ spring:
           filters:
             - AuthorizationFilter
             - RewritePath=/member-service/?(?<segment>.*), /$\{segment} # /member-service/xxx 로 요청이 오면 /xxx 로 변경하여 요청한다.
+        # Buddy Service Route Set
+        - id: buddy-service-with-auth
+          predicates:
+            - Path=/buddy-service/**
+          uri: lb://BUDDY-SERVICE
+          filters:
+            - AuthorizationFilter
+            - RewritePath=/buddy-service/?(?<segment>.*), /$\{segment}
+        - id: buddy-service-without-auth
+          predicates:
+            - Path=/buddy-service/v1/ping
+          uri: lb://BUDDY-SERVICE
+          filters:
+            - RewritePath=/buddy-service/?(?<segment>.*), /$\{segment}
 jwt:
   key: ${JWT_KEY}


### PR DESCRIPTION
- 버디 일정 서비스 local 프로파일 YAML 설정.
- 버디 일정 서비스 디스커버리 클라이언트 라이브러리 적용
- 유레카 서버로 디스커버리 클라이언트 등록 확인.
- 게이트웨이 서비스 라우팅 설정.
- 테스트용 ping pong API 생성 ( ..buddy-service/v1/ping )
- Root ReadMe 버디 일정 이벤트 ReadMe 연결.