### PR TITLE
#17 - Entity Auditing 관리

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.freediving.common'
+version = '0.0.1'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform('org.junit:junit-bom:5.9.1')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/common/src/main/java/com/freediving/common/AuditableEntity.java
+++ b/common/src/main/java/com/freediving/common/AuditableEntity.java
@@ -1,0 +1,21 @@
+package com.freediving.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AuditableEntity {
+	@CreatedDate
+	private LocalDateTime createdDate;
+	@LastModifiedDate
+	private LocalDateTime updatedDate;
+}

--- a/common/src/main/java/com/freediving/common/CreatedDateEntity.java
+++ b/common/src/main/java/com/freediving/common/CreatedDateEntity.java
@@ -1,0 +1,18 @@
+package com.freediving.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class CreatedDateEntity {
+	@CreatedDate
+	private LocalDateTime createdDate;
+}

--- a/common/src/main/java/com/freediving/common/UpdatedDateEntity.java
+++ b/common/src/main/java/com/freediving/common/UpdatedDateEntity.java
@@ -1,0 +1,19 @@
+package com.freediving.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class UpdatedDateEntity {
+
+	@LastModifiedDate
+	private LocalDateTime updatedDate;
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,5 @@ include 'buddy-service'
 include 'discovery-service'
 include 'discovery-service'
 include 'gateway-service'
+include 'common'
 


### PR DESCRIPTION
Common 모듈 생성
 - Auditing 관리 객체 3가지
   - AuditableEntity ( CreatedDate, UpdatedDate Auditing )
   - CreatedDateEntity ( CreatedDate Auditing )
   - UpdatedDateEntity( UpdatedDate Auditing )


## 사용 예

### 각 도메인 서비스의 build.gradle에 common 모듈 종속성 추가해주시면 됩니다.
```gradle
dependencies {
    implementation project(':common')
    ...
}
```

### 1. Entity ( CreatedDate & UpdatedDate   Auditing )
```java
import com.freediving.common.AuditableEntity;

@Entity
public class BuddyEvents extends AuditableEntity {
...
}
```

### 2. Entity ( CreatedDate Auditing )
```java
import com.freediving.common.CreatedDateEntity ;

@Entity
public class BuddyEvents extends CreatedDateEntity {
...
}
```

### 3. Entity ( UpdatedDate   Auditing )
```java
import com.freediving.common.UpdatedDateEntity;

@Entity
public class BuddyEvents extends UpdatedDateEntity{
...
}
```
