### PR TITLE
feat: #25 - AuthService 소셜로그인 / JWT 생성 로직 개발

### DIFF
--- a/member-service/build.gradle
+++ b/member-service/build.gradle
@@ -17,13 +17,29 @@ dependencyManagement {
 }
 
 dependencies {
+    implementation project(':common')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
-//	runtimeOnly 'com.h2database:h2'
+    testImplementation 'com.h2database:h2'
+    runtimeOnly 'com.h2database:h2'
+
+    // jwt
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+
+    // ConfigurationProperties
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
+    // FeignClient
+    implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+
 }
 
 

--- a/member-service/src/main/java/com/freediving/MemberServiceApplication.java
+++ b/member-service/src/main/java/com/freediving/MemberServiceApplication.java
@@ -2,10 +2,17 @@ package com.freediving;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableJpaAuditing
+@EnableFeignClients
+@ConfigurationPropertiesScan
+
 public class MemberServiceApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(MemberServiceApplication.class, args);

--- a/member-service/src/main/java/com/freediving/authservice/adapter/in/web/OauthController.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/in/web/OauthController.java
@@ -1,0 +1,51 @@
+package com.freediving.authservice.adapter.in.web;
+
+import java.io.IOException;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.freediving.authservice.application.port.in.OauthUseCase;
+import com.freediving.authservice.domain.OauthType;
+import com.freediving.common.config.annotation.WebAdapter;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/oauth")
+@Slf4j
+public class OauthController {
+
+	private final OauthUseCase oauthUseCase;
+
+	@GetMapping("/{socialType}")
+	public ResponseEntity<Void> redirectAuthLogin(@PathVariable String socialType, HttpServletResponse response) {
+		String redirectUrl = oauthUseCase.provideOauthType(OauthType.from(socialType));
+		// TODO : 예외 처리 및 응답 포맷 결정 후 보완
+		if (StringUtils.hasText(redirectUrl)) {
+			try {
+				response.sendRedirect(redirectUrl);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/login/{socialType}")
+	public ResponseEntity<UserLoginResponse> login(@PathVariable String socialType, @RequestParam("code") String code) {
+		UserLoginResponse userLoginResponse = oauthUseCase.login(OauthType.from(socialType), code);
+		return ResponseEntity.ok().body(userLoginResponse);
+	}
+
+	// TODO : 액세스 토큰 재발급
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/in/web/UserLoginResponse.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/in/web/UserLoginResponse.java
@@ -1,0 +1,37 @@
+package com.freediving.authservice.adapter.in.web;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.freediving.authservice.domain.OauthType;
+import com.freediving.authservice.domain.OauthUser;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+public class UserLoginResponse {
+	private OauthType oauthType;
+	private String email;
+	private String profileImgUrl;
+
+	private String accessToken;
+
+	private String refreshToken;
+
+	public void updateTokens(String accessToken, String refreshToken) {
+		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
+	}
+
+	public UserLoginResponse(OauthType oauthType, String email, String profileImgUrl) {
+		this.oauthType = oauthType;
+		this.email = email;
+		this.profileImgUrl = profileImgUrl;
+	}
+
+	public static UserLoginResponse from(OauthUser oauthUser) {
+		return new UserLoginResponse(oauthUser.getOauthType(), oauthUser.getEmail(), oauthUser.getProfileImgUrl());
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/OauthResponse.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/OauthResponse.java
@@ -1,0 +1,10 @@
+package com.freediving.authservice.adapter.out.external;
+
+import com.freediving.authservice.domain.OauthType;
+
+public record OauthResponse(OauthType oauthType, String email, String profileImgUrl) {
+
+	public static OauthResponse of(OauthType oauthType, String email, String profileImgUrl) {
+		return new OauthResponse(oauthType, email, profileImgUrl);
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/google/GoogleInfoResponse.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/google/GoogleInfoResponse.java
@@ -1,0 +1,17 @@
+package com.freediving.authservice.adapter.out.external.google;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GoogleInfoResponse(
+	Long sub,
+	String name,
+	String givenName,
+	String familyName,
+	String picture,
+	String email,
+	String emailVerified,
+	String locale
+) {
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/google/GoogleOauthExternalAdapter.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/google/GoogleOauthExternalAdapter.java
@@ -1,0 +1,77 @@
+package com.freediving.authservice.adapter.out.external.google;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.freediving.authservice.adapter.out.external.OauthResponse;
+import com.freediving.authservice.application.port.out.MemberServiceFeignClient;
+import com.freediving.authservice.application.port.out.OauthFeignPort;
+import com.freediving.authservice.application.port.out.google.GoogleInfoFeignClient;
+import com.freediving.authservice.application.port.out.google.GoogleTokenFeignClient;
+import com.freediving.authservice.config.GoogleOauthConfig;
+import com.freediving.authservice.domain.OauthType;
+import com.freediving.authservice.domain.OauthUser;
+import com.freediving.common.config.annotation.ExternalSystemAdapter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@ExternalSystemAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleOauthExternalAdapter implements OauthFeignPort {
+
+	private final GoogleOauthConfig googleOauthConfig;
+	private final GoogleTokenFeignClient googleTokenFeignClient;
+	private final GoogleInfoFeignClient googleInfoFeignClient;
+
+	private final MemberServiceFeignClient memberServiceFeignClient;
+
+	@Override
+	public OauthType getOauthType() {
+		return OauthType.GOOGLE;
+	}
+
+	@Override
+	public String createRequestUrl() {
+		String url = UriComponentsBuilder
+			.fromUriString(googleOauthConfig.codeUri())
+			.queryParam("client_id", googleOauthConfig.clientId())
+			.queryParam("redirect_uri", googleOauthConfig.redirectUri())
+			.queryParam("response_type", "code")
+			.queryParam("scope", googleOauthConfig.scope())
+			.toUriString();
+
+		log.info("GOOGLE REQUEST URL : {} ", url);
+		return url;
+	}
+
+	@Override
+	public OauthUser fetch(String code) {
+		GoogleTokenResponse googleTokenResponse = googleTokenFeignClient.postToken(tokenParamMap(code));
+		log.info("GOOGLE TOKEN : {}", googleTokenResponse);
+		GoogleInfoResponse googleInfoResponse = googleInfoFeignClient.postInfo(
+			"Bearer " + googleTokenResponse.accessToken());
+		log.info("GOOGLE INFO : {}", googleInfoResponse);
+
+		OauthResponse oauthResponse = OauthResponse.of(getOauthType(), googleInfoResponse.email(),
+			googleInfoResponse.picture());
+
+		OauthUser oauthUser = OauthUser.from(oauthResponse);
+		memberServiceFeignClient.postOauthUserInfo(oauthUser);
+		return oauthUser;
+	}
+
+	private MultiValueMap<String, String> tokenParamMap(String code) {
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("client_id", googleOauthConfig.clientId());
+		params.add("client_secret", googleOauthConfig.clientSecret());
+		params.add("code", code);
+		params.add("grant_type", "authorization_code");
+		params.add("redirect_uri", googleOauthConfig.redirectUri());
+		return params;
+	}
+}
+
+

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/google/GoogleTokenResponse.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/google/GoogleTokenResponse.java
@@ -1,0 +1,14 @@
+package com.freediving.authservice.adapter.out.external.google;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record GoogleTokenResponse(
+	String accessToken,
+	Integer expiresIn,
+	String tokenType,
+	String scope,
+	String refreshToken
+) {
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/kakao/KaKaoTokenResponse.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/kakao/KaKaoTokenResponse.java
@@ -1,0 +1,16 @@
+package com.freediving.authservice.adapter.out.external.kakao;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KaKaoTokenResponse(
+	String tokenType,
+	String accessToken,
+	String idToken,
+	Integer expiresIn,
+	String refreshToken,
+	Integer refreshTokenExpiresIn,
+	String scope
+) {
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/kakao/KakaoInfoResponse.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/kakao/KakaoInfoResponse.java
@@ -1,0 +1,53 @@
+package com.freediving.authservice.adapter.out.external.kakao;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record KakaoInfoResponse(
+	Long id,
+	boolean hasSignedUp,
+	LocalDateTime connectedAt,
+	KakaoAccount kakaoAccount
+) {
+
+	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+	public record KakaoAccount(
+		boolean profileNeedsAgreement,
+		boolean profileNicknameNeedsAgreement,
+		boolean profileImageNeedsAgreement,
+		Profile profile,
+		boolean nameNeedsAgreement,
+		String name,
+		boolean emailNeedsAgreement,
+		boolean isEmailValid,
+		boolean isEmailVerified,
+		String email,
+		boolean ageRangeNeedsAgreement,
+		String ageRange,
+		boolean birthyearNeedsAgreement,
+		String birthyear,
+		boolean birthdayNeedsAgreement,
+		String birthday,
+		String birthdayType,
+		boolean genderNeedsAgreement,
+		String gender,
+		boolean phoneNumberNeedsAgreement,
+		String phoneNumber,
+		boolean ciNeedsAgreement,
+		String ci,
+		LocalDateTime ciAuthenticatedAt
+	) {
+	}
+
+	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+	public record Profile(
+		String nickname,
+		String thumbnailImageUrl,
+		String profileImageUrl,
+		boolean isDefaultImage
+	) {
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/kakao/KakaoOauthExternalAdapter.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/kakao/KakaoOauthExternalAdapter.java
@@ -1,0 +1,73 @@
+package com.freediving.authservice.adapter.out.external.kakao;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.freediving.authservice.adapter.out.external.OauthResponse;
+import com.freediving.authservice.application.port.out.MemberServiceFeignClient;
+import com.freediving.authservice.application.port.out.OauthFeignPort;
+import com.freediving.authservice.application.port.out.kakao.KakaoInfoFeignClient;
+import com.freediving.authservice.application.port.out.kakao.KakaoTokenFeignClient;
+import com.freediving.authservice.config.KakaoOauthConfig;
+import com.freediving.authservice.domain.OauthType;
+import com.freediving.authservice.domain.OauthUser;
+import com.freediving.common.config.annotation.ExternalSystemAdapter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@ExternalSystemAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoOauthExternalAdapter implements OauthFeignPort {
+
+	private final KakaoOauthConfig kakaoOauthConfig;
+
+	private final KakaoTokenFeignClient kakaoTokenFeignClient;
+	private final KakaoInfoFeignClient kakaoInfoFeignClient;
+	private final MemberServiceFeignClient memberServiceFeignClient;
+
+	@Override
+	public OauthType getOauthType() {
+		return OauthType.KAKAO;
+	}
+
+	@Override
+	public String createRequestUrl() {
+		return UriComponentsBuilder
+			.fromUriString(kakaoOauthConfig.codeUri())
+			.queryParam("response_type", "code")
+			.queryParam("client_id", kakaoOauthConfig.clientId())
+			.queryParam("redirect_uri", kakaoOauthConfig.redirectUri())
+			.queryParam("scope", String.join(",", kakaoOauthConfig.scope()))
+			.toUriString();
+	}
+
+	@Override
+	public OauthUser fetch(String code) {
+		KaKaoTokenResponse kaKaoTokenResponse = kakaoTokenFeignClient.postToken(tokenParamMap(code));
+		log.info("KAKAO TOKEN RESPONSE : {}", kaKaoTokenResponse);
+
+		KakaoInfoResponse kakaoInfoResponse = kakaoInfoFeignClient.postInfo(
+			"Bearer " + kaKaoTokenResponse.accessToken());
+		log.info("KAKAO INFO RESPONSE : {}", kakaoInfoResponse);
+
+		OauthResponse oauthResponse = OauthResponse.of(getOauthType(), kakaoInfoResponse.kakaoAccount().email(),
+			kakaoInfoResponse.kakaoAccount().profile().profileImageUrl());
+		OauthUser oauthUser = OauthUser.from(oauthResponse);
+		memberServiceFeignClient.postOauthUserInfo(oauthUser);
+
+		return oauthUser;
+	}
+
+	private MultiValueMap<String, String> tokenParamMap(String code) {
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("grant_type", "authorization_code");
+		params.add("client_id", kakaoOauthConfig.clientId());
+		params.add("redirect_uri", kakaoOauthConfig.redirectUri());
+		params.add("client_secret", kakaoOauthConfig.clientSecret());
+		params.add("code", code);
+		return params;
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/naver/NaverInfoResponse.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/naver/NaverInfoResponse.java
@@ -1,0 +1,27 @@
+package com.freediving.authservice.adapter.out.external.naver;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record NaverInfoResponse(
+	String resultcode,
+	String message,
+	Response response
+) {
+
+	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+	public record Response(
+		String id,
+		String nickname,
+		String name,
+		String email,
+		String gender,
+		String age,
+		String birthday,
+		String profileImage,
+		String birthyear,
+		String mobile
+	) {
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/naver/NaverOauthExternalAdapter.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/naver/NaverOauthExternalAdapter.java
@@ -1,0 +1,77 @@
+package com.freediving.authservice.adapter.out.external.naver;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.freediving.authservice.adapter.out.external.OauthResponse;
+import com.freediving.authservice.application.port.out.MemberServiceFeignClient;
+import com.freediving.authservice.application.port.out.OauthFeignPort;
+import com.freediving.authservice.application.port.out.naver.NaverInfoFeignClient;
+import com.freediving.authservice.application.port.out.naver.NaverTokenFeignClient;
+import com.freediving.authservice.config.NaverOauthConfig;
+import com.freediving.authservice.domain.OauthType;
+import com.freediving.authservice.domain.OauthUser;
+import com.freediving.common.config.annotation.ExternalSystemAdapter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@ExternalSystemAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class NaverOauthExternalAdapter implements OauthFeignPort {
+
+	private final NaverOauthConfig naverOauthConfig;
+	private final NaverTokenFeignClient naverTokenFeignClient;
+	private final NaverInfoFeignClient naverInfoFeignClient;
+	private final MemberServiceFeignClient memberServiceFeignClient;
+
+	@Override
+	public OauthType getOauthType() {
+		return OauthType.NAVER;
+	}
+
+	@Override
+	public String createRequestUrl() {
+		String url = UriComponentsBuilder
+			.fromUriString(naverOauthConfig.codeUri())
+			.queryParam("response_type", "code")
+			.queryParam("client_id", naverOauthConfig.clientId())
+			.queryParam("redirect_uri", naverOauthConfig.redirectUri())
+			.queryParam("state", naverOauthConfig.state())
+			.build()
+			.toUriString();
+
+		log.info("NAVER createRequestURL : {} ", url);
+		return url;
+	}
+
+	@Override
+	public OauthUser fetch(String code) {
+		NaverTokenResponse naverTokenResponse = naverTokenFeignClient.postToken(tokenParamMap(code));
+
+		log.info("NAVER TOKEN {}", naverTokenResponse);
+
+		NaverInfoResponse naverInfoResponse = naverInfoFeignClient.postInfo(
+			"Bearer " + naverTokenResponse.accessToken());
+
+		log.info("NAVER INFO {}", naverInfoResponse);
+
+		OauthResponse oauthResponse = OauthResponse.of(getOauthType(), naverInfoResponse.response().email(),
+			naverInfoResponse.response().profileImage());
+		OauthUser oauthUser = OauthUser.from(oauthResponse);
+		memberServiceFeignClient.postOauthUserInfo(oauthUser);
+		return oauthUser;
+	}
+
+	private MultiValueMap<String, String> tokenParamMap(String code) {
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("grant_type", "authorization_code");
+		params.add("client_id", naverOauthConfig.clientId());
+		params.add("client_secret", naverOauthConfig.clientSecret());
+		params.add("code", code);
+		params.add("state", naverOauthConfig.state());
+		return params;
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/naver/NaverTokenResponse.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/naver/NaverTokenResponse.java
@@ -1,0 +1,15 @@
+package com.freediving.authservice.adapter.out.external.naver;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record NaverTokenResponse(
+	String accessToken,
+	String refreshToken,
+	String tokenType,
+	Integer expiresIn,
+	String error,
+	String errorDescription
+) {
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/in/JwtTokenUseCase.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/in/JwtTokenUseCase.java
@@ -1,0 +1,10 @@
+package com.freediving.authservice.application.port.in;
+
+import com.freediving.authservice.adapter.in.web.UserLoginResponse;
+import com.freediving.common.config.annotation.UseCase;
+
+@UseCase
+public interface JwtTokenUseCase {
+
+	void provideJwtToken(UserLoginResponse userLoginResponse);
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/in/JwtTokenUtils.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/in/JwtTokenUtils.java
@@ -1,0 +1,43 @@
+package com.freediving.authservice.application.port.in;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+import com.freediving.authservice.domain.OauthType;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+public class JwtTokenUtils {
+
+	private static final long EXPIRED_ACCESS_TIME = 5 * 60 * 60 * 1000L;
+	private static final long EXPIRED_REFRESH_TIME = 30 * 24 * 60 * 60 * 1000L;
+
+	public static String generateAccessToken(OauthType oauthType, String email, String key) {
+		return generateToken(oauthType, email, key, EXPIRED_ACCESS_TIME);
+	}
+
+	public static String generateRefreshToken(OauthType oauthType, String email, String key) {
+		return generateToken(oauthType, email, key, EXPIRED_REFRESH_TIME);
+	}
+
+	private static Key getKey(String key) {
+		byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+		return Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	private static String generateToken(OauthType oauthType, String email, String key, long expiredTime) {
+		Claims claims = Jwts.claims();
+		claims.put("oauthType", oauthType.name());
+		claims.put("email", email);
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(new Date(System.currentTimeMillis()))
+			.setExpiration(new Date(System.currentTimeMillis() + expiredTime))
+			.signWith(getKey(key), SignatureAlgorithm.HS256)
+			.compact();
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/in/OauthUseCase.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/in/OauthUseCase.java
@@ -1,0 +1,13 @@
+package com.freediving.authservice.application.port.in;
+
+import com.freediving.authservice.adapter.in.web.UserLoginResponse;
+import com.freediving.authservice.domain.OauthType;
+import com.freediving.common.config.annotation.UseCase;
+
+@UseCase
+public interface OauthUseCase {
+
+	String provideOauthType(OauthType oauthType);
+
+	UserLoginResponse login(OauthType oauthType, String code);
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/MemberServiceFeignClient.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/MemberServiceFeignClient.java
@@ -1,0 +1,13 @@
+package com.freediving.authservice.application.port.out;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import com.freediving.authservice.domain.OauthUser;
+
+@FeignClient(name = "MEMBER-SERVICE")
+public interface MemberServiceFeignClient {
+
+	@PostMapping(path = "/v1/users/register")
+	void postOauthUserInfo(OauthUser oauthUser);
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/OauthFeignPort.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/OauthFeignPort.java
@@ -1,0 +1,8 @@
+package com.freediving.authservice.application.port.out;
+
+import com.freediving.authservice.domain.OauthUser;
+
+public interface OauthFeignPort extends OauthRedirectUrlPort {
+
+	OauthUser fetch(String code);
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/OauthRedirectUrlPort.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/OauthRedirectUrlPort.java
@@ -1,0 +1,14 @@
+package com.freediving.authservice.application.port.out;
+
+import com.freediving.authservice.domain.OauthType;
+
+public interface OauthRedirectUrlPort {
+
+	OauthType getOauthType();
+
+	String createRequestUrl();
+
+	default boolean canRequest(OauthType oauthType) {
+		return getOauthType().equals(oauthType);
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/OauthTemplate.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/OauthTemplate.java
@@ -1,0 +1,44 @@
+package com.freediving.authservice.application.port.out;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+import com.freediving.authservice.domain.OauthType;
+import com.freediving.authservice.domain.OauthUser;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OauthTemplate implements InitializingBean {
+	private final List<OauthFeignPort> feignPortList;
+	private Map<OauthType, OauthFeignPort> feignPortMap;
+
+	public String doRequest(OauthType oauthType) {
+		return Optional.ofNullable(feignPortMap.get(oauthType))
+			.filter(port -> port.canRequest(oauthType))
+			.map(OauthRedirectUrlPort::createRequestUrl)
+			.orElseThrow(() -> new NoSuchElementException("No OauthRedirectUrlPort found for " + oauthType));
+	}
+
+	public OauthUser doPostTokenAndGetInfo(OauthType oauthType, String code) {
+		return Optional.ofNullable(feignPortMap.get(oauthType))
+			.filter(port -> port.canRequest(oauthType))
+			.map(port -> port.fetch(code))
+			.orElseThrow(() -> new NoSuchElementException("No OauthFeignPort found for " + oauthType));
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		feignPortMap = feignPortList.stream()
+			.collect(Collectors.toMap(OauthFeignPort::getOauthType, Function.identity()));
+	}
+
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/google/GoogleInfoFeignClient.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/google/GoogleInfoFeignClient.java
@@ -1,0 +1,14 @@
+package com.freediving.authservice.application.port.out.google;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import com.freediving.authservice.adapter.out.external.google.GoogleInfoResponse;
+
+@FeignClient(name = "googleInfoFeignClient", url = "${oauth.google.resource_uri}")
+public interface GoogleInfoFeignClient {
+
+	@GetMapping
+	GoogleInfoResponse postInfo(@RequestHeader(name = "Authorization") String token);
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/google/GoogleTokenFeignClient.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/google/GoogleTokenFeignClient.java
@@ -1,0 +1,16 @@
+package com.freediving.authservice.application.port.out.google;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.freediving.authservice.adapter.out.external.google.GoogleTokenResponse;
+
+@FeignClient(name = "googleTokenFeignClient", url = "${oauth.google.token_uri}")
+public interface GoogleTokenFeignClient {
+
+	@PostMapping(path = "", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	GoogleTokenResponse postToken(@RequestParam MultiValueMap<String, String> params);
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/kakao/KakaoInfoFeignClient.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/kakao/KakaoInfoFeignClient.java
@@ -1,0 +1,14 @@
+package com.freediving.authservice.application.port.out.kakao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import com.freediving.authservice.adapter.out.external.kakao.KakaoInfoResponse;
+
+@FeignClient(name = "kakaoInfoFeignClient", url = "${oauth.kakao.resource_uri}")
+public interface KakaoInfoFeignClient {
+
+	@GetMapping
+	KakaoInfoResponse postInfo(@RequestHeader(name = "Authorization") String token);
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/kakao/KakaoTokenFeignClient.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/kakao/KakaoTokenFeignClient.java
@@ -1,0 +1,16 @@
+package com.freediving.authservice.application.port.out.kakao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.freediving.authservice.adapter.out.external.kakao.KaKaoTokenResponse;
+
+@FeignClient(name = "kakaoTokenFeignClient", url = "${oauth.kakao.token_uri}")
+public interface KakaoTokenFeignClient {
+	@PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	KaKaoTokenResponse postToken(@RequestParam MultiValueMap<String, String> params);
+
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/naver/NaverInfoFeignClient.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/naver/NaverInfoFeignClient.java
@@ -1,0 +1,14 @@
+package com.freediving.authservice.application.port.out.naver;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import com.freediving.authservice.adapter.out.external.naver.NaverInfoResponse;
+
+@FeignClient(name = "naverInfoFeignClient", url = "${oauth.naver.resource_uri}")
+public interface NaverInfoFeignClient {
+
+	@GetMapping
+	NaverInfoResponse postInfo(@RequestHeader(name = "Authorization") String token);
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/naver/NaverTokenFeignClient.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/naver/NaverTokenFeignClient.java
@@ -1,0 +1,17 @@
+package com.freediving.authservice.application.port.out.naver;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.freediving.authservice.adapter.out.external.naver.NaverTokenResponse;
+
+@FeignClient(name = "naverTokenFeignClient", url = "${oauth.naver.token_uri}")
+public interface NaverTokenFeignClient {
+
+	@PostMapping(consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	NaverTokenResponse postToken(@RequestParam MultiValueMap<String, String> params);
+
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/service/OauthService.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/service/OauthService.java
@@ -1,0 +1,51 @@
+package com.freediving.authservice.application.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.freediving.authservice.adapter.in.web.UserLoginResponse;
+import com.freediving.authservice.application.port.in.JwtTokenUseCase;
+import com.freediving.authservice.application.port.in.JwtTokenUtils;
+import com.freediving.authservice.application.port.in.OauthUseCase;
+import com.freediving.authservice.application.port.out.OauthTemplate;
+import com.freediving.authservice.domain.OauthType;
+import com.freediving.authservice.domain.OauthUser;
+import com.freediving.common.config.annotation.UseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class OauthService implements OauthUseCase, JwtTokenUseCase {
+
+	@Value("${jwt.key}")
+	private String key;
+
+	private final OauthTemplate oauthTemplate;
+
+	@Override
+	public String provideOauthType(OauthType oauthType) {
+		return oauthTemplate.doRequest(oauthType);
+	}
+
+	@Override
+	public UserLoginResponse login(OauthType oauthType, String code) {
+		OauthUser oauthUser = oauthTemplate.doPostTokenAndGetInfo(oauthType, code);
+		UserLoginResponse userLoginResponse = UserLoginResponse.from(oauthUser);
+		// JWT Token 생성
+		provideJwtToken(userLoginResponse);
+		return userLoginResponse;
+	}
+
+	@Override
+	public void provideJwtToken(UserLoginResponse userLoginResponse) {
+		OauthType oauthType = userLoginResponse.getOauthType();
+		String email = userLoginResponse.getEmail();
+		String accessToken = JwtTokenUtils.generateAccessToken(oauthType, email, key);
+		String refreshToken = JwtTokenUtils.generateRefreshToken(oauthType, email, key);
+		userLoginResponse.updateTokens(accessToken, refreshToken);
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/config/GoogleOauthConfig.java
+++ b/member-service/src/main/java/com/freediving/authservice/config/GoogleOauthConfig.java
@@ -1,0 +1,14 @@
+package com.freediving.authservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.google")
+public record GoogleOauthConfig(
+	String redirectUri,
+	String clientId,
+	String clientSecret,
+	String scope,
+	String codeUri
+) {
+}
+

--- a/member-service/src/main/java/com/freediving/authservice/config/KakaoOauthConfig.java
+++ b/member-service/src/main/java/com/freediving/authservice/config/KakaoOauthConfig.java
@@ -1,0 +1,14 @@
+package com.freediving.authservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoOauthConfig(
+	String clientId,
+	String redirectUri,
+	String clientSecret,
+	String[] scope,
+
+	String codeUri
+) {
+}

--- a/member-service/src/main/java/com/freediving/authservice/config/NaverOauthConfig.java
+++ b/member-service/src/main/java/com/freediving/authservice/config/NaverOauthConfig.java
@@ -1,0 +1,13 @@
+package com.freediving.authservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.naver")
+public record NaverOauthConfig(
+	String redirectUri,
+	String clientId,
+	String clientSecret,
+	String state,
+	String codeUri
+) {
+}

--- a/member-service/src/main/java/com/freediving/authservice/domain/OauthType.java
+++ b/member-service/src/main/java/com/freediving/authservice/domain/OauthType.java
@@ -1,0 +1,27 @@
+package com.freediving.authservice.domain;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+public enum OauthType {
+	GOOGLE("GOOGLE"),
+	NAVER("NAVER"),
+	KAKAO("KAKAO");
+
+	private final String name;
+
+	OauthType(String name) {
+		this.name = name;
+	}
+
+	public static OauthType from(String type) {
+		return Arrays.stream(OauthType.values())
+			.filter(value -> value.getName().equals(type.toUpperCase()))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("지원하지 않는 소셜 로그인 타입입니다."));
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/domain/OauthUser.java
+++ b/member-service/src/main/java/com/freediving/authservice/domain/OauthUser.java
@@ -1,0 +1,20 @@
+package com.freediving.authservice.domain;
+
+import com.freediving.authservice.adapter.out.external.OauthResponse;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OauthUser {
+
+	private OauthType oauthType;
+	private String email;
+	private String profileImgUrl;
+
+	public static OauthUser from(OauthResponse oauthResponse) {
+		return new OauthUser(oauthResponse.oauthType(), oauthResponse.email(), oauthResponse.profileImgUrl());
+	}
+}

--- a/member-service/src/main/java/com/freediving/memberservice/adapter/in/web/HelloController.java
+++ b/member-service/src/main/java/com/freediving/memberservice/adapter/in/web/HelloController.java
@@ -1,4 +1,4 @@
-package com.freediving.adapter.in.web;
+package com.freediving.memberservice.adapter.in.web;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HelloController {
 
-    @GetMapping("/")
-    public String hello(){
-        return "Hello";
-    }
+	@GetMapping("/")
+	public String hello() {
+		return "Hello";
+	}
 }

--- a/member-service/src/main/resources/application-local.yml
+++ b/member-service/src/main/resources/application-local.yml
@@ -1,9 +1,28 @@
 server:
-  port: 0 # 랜덤 포트 할당
+  port: 0
 
 spring:
   application:
     name: member-service
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:tcp://localhost/~/member
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+        show_sql: true
+
 eureka:
   instance:
     hostname: localhost
@@ -18,3 +37,39 @@ eureka:
     service-url:
       # endpoint 지정
       defaultZone: http://localhost:8761/eureka
+
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 5000
+        readTimeout: 5000
+
+oauth:
+  kakao:
+    client_id: ${KAKAO_CLIENT_ID}
+    redirect_uri: ${KAKAO_REDIRECT_URI}
+    client_secret: ${KAKAO_CLIENT_SECRET}
+    scope: profile_image, account_email
+    code_uri: https://kauth.kakao.com/oauth/authorize
+    token_uri: https://kauth.kakao.com/oauth/token
+    resource_uri: https://kapi.kakao.com/v2/user/me
+  naver:
+    client_id: ${NAVER_CLIENT_ID}
+    redirect_uri: ${NAVER_REDIRECT_URI}
+    client_secret: ${NAVER_CLIENT_SECRET}
+    state: ${NAVER_STATE}
+    code_uri: https://nid.naver.com/oauth2.0/authorize
+    token_uri: https://nid.naver.com/oauth2.0/token
+    resource_uri: https://openapi.naver.com/v1/nid/me
+  google:
+    client_id: ${GOOGLE_CLIENT_ID}
+    redirect_uri: ${GOOGLE_REDIRECT_URI}
+    client_secret: ${GOOGLE_CLIENT_SECRET}
+    scope: https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile
+    code_uri: https://accounts.google.com/o/oauth2/v2/auth
+    token_uri: https://oauth2.googleapis.com/token
+    resource_uri: https://www.googleapis.com/oauth2/v2/userinfo
+
+jwt:
+  key: ${JWT_KEY}


### PR DESCRIPTION
## MemberService 내 인증/인가를 수행하는 AuthService 초기 설정 

#25 을 참고해주세요!

### 소셜로그인 
- 인증/인가 서버는 MemberService 내에서 분리 가능성을 두고 스프링 시큐리티를 적용하지 않고 소셜로그인을 구현했습니다.
- 소셜로그인 개발 (구글, 카카오, 네이버)
> client에서 소셜로그인 secret 변수를 관리하지 않도록 서버 내에서 모든 로직을 처리하고, redirect_uri 만 client에서 받도록 구현했습니다.

### 회원가입
- 유저가 소셜로그인 가입 성공 시 JWT를 생성하여 응답값에 반환하도록 설정하였습니다. 