### PR TITLE
feat: #2 - MemberService User 소셜로그인 초기 설정

### DIFF
--- a/member-service/src/main/java/com/freediving/memberservice/adapter/in/web/CreateUserController.java
+++ b/member-service/src/main/java/com/freediving/memberservice/adapter/in/web/CreateUserController.java
@@ -1,0 +1,32 @@
+package com.freediving.memberservice.adapter.in.web;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.freediving.common.config.annotation.WebAdapter;
+import com.freediving.memberservice.application.port.in.CreateUserCommand;
+import com.freediving.memberservice.application.port.in.CreateUserUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/users")
+public class CreateUserController {
+
+	private final CreateUserUseCase userUseCase;
+
+	@PostMapping("/register")
+	public void createUser(@RequestBody CreateUserRequest request) {
+		CreateUserCommand command = CreateUserCommand.builder()
+			.oauthType(request.getOauthType())
+			.email(request.getEmail())
+			.profileImgUrl(request.getProfileImgUrl())
+			.build();
+		userUseCase.createUser(command);
+	}
+
+}

--- a/member-service/src/main/java/com/freediving/memberservice/adapter/in/web/CreateUserRequest.java
+++ b/member-service/src/main/java/com/freediving/memberservice/adapter/in/web/CreateUserRequest.java
@@ -1,0 +1,17 @@
+package com.freediving.memberservice.adapter.in.web;
+
+import com.freediving.memberservice.domain.OauthType;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateUserRequest {
+
+	private OauthType oauthType;
+	private String email;
+	private String profileImgUrl;
+}

--- a/member-service/src/main/java/com/freediving/memberservice/adapter/in/web/FindUserController.java
+++ b/member-service/src/main/java/com/freediving/memberservice/adapter/in/web/FindUserController.java
@@ -1,0 +1,32 @@
+package com.freediving.memberservice.adapter.in.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.freediving.common.config.annotation.WebAdapter;
+import com.freediving.memberservice.application.port.in.FindUserCommand;
+import com.freediving.memberservice.application.port.in.FindUserUseCase;
+import com.freediving.memberservice.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/users")
+public class FindUserController {
+
+	private final FindUserUseCase findUserUseCase;
+
+	@GetMapping("/{userId}")
+	ResponseEntity<User> findUserByUserId(@PathVariable Long userId) {
+		FindUserCommand findUserCommand = FindUserCommand.builder()
+			.userId(userId)
+			.build();
+
+		return ResponseEntity.ok(findUserUseCase.findUser(findUserCommand));
+	}
+}

--- a/member-service/src/main/java/com/freediving/memberservice/adapter/out/persistence/UserJpaEntity.java
+++ b/member-service/src/main/java/com/freediving/memberservice/adapter/out/persistence/UserJpaEntity.java
@@ -1,0 +1,38 @@
+package com.freediving.memberservice.adapter.out.persistence;
+
+import com.freediving.common.persistence.AuditableEntity;
+import com.freediving.memberservice.domain.OauthType;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class UserJpaEntity extends AuditableEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long userId;
+
+	@Enumerated(value = EnumType.STRING)
+	private OauthType oauthType;
+	private String email;
+	private String profileImgUrl;
+
+	public UserJpaEntity(OauthType oauthType, String email, String profileImgUrl) {
+		this.email = email;
+		this.profileImgUrl = profileImgUrl;
+		this.oauthType = oauthType;
+	}
+}

--- a/member-service/src/main/java/com/freediving/memberservice/adapter/out/persistence/UserMapper.java
+++ b/member-service/src/main/java/com/freediving/memberservice/adapter/out/persistence/UserMapper.java
@@ -1,0 +1,15 @@
+package com.freediving.memberservice.adapter.out.persistence;
+
+import org.springframework.stereotype.Component;
+
+import com.freediving.memberservice.domain.User;
+
+@Component
+public class UserMapper {
+
+	User fromUserJpaEntity(UserJpaEntity userJpaEntity) {
+		return User.createUser(userJpaEntity.getUserId(), userJpaEntity.getOauthType(), userJpaEntity.getEmail(),
+			userJpaEntity.getProfileImgUrl());
+	}
+
+}

--- a/member-service/src/main/java/com/freediving/memberservice/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/member-service/src/main/java/com/freediving/memberservice/adapter/out/persistence/UserPersistenceAdapter.java
@@ -1,0 +1,38 @@
+package com.freediving.memberservice.adapter.out.persistence;
+
+import org.springframework.util.ObjectUtils;
+
+import com.freediving.common.config.annotation.PersistenceAdapter;
+import com.freediving.memberservice.application.port.out.CreateUserPort;
+import com.freediving.memberservice.application.port.out.FindUserPort;
+import com.freediving.memberservice.domain.OauthType;
+import com.freediving.memberservice.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class UserPersistenceAdapter implements CreateUserPort, FindUserPort {
+
+	private final UserRepository userRepository;
+	private final UserMapper userMapper;
+
+	@Override
+	public void createUser(OauthType oauthType, String email, String profileImgUrl) {
+
+		UserJpaEntity findUserJpaEntity = userRepository.findByOauthTypeAndEmail(oauthType, email);
+		if (ObjectUtils.isEmpty(findUserJpaEntity)) {
+			UserJpaEntity userEntity = new UserJpaEntity(oauthType, email, profileImgUrl);
+			userRepository.save(userEntity);
+		}
+	}
+
+	@Override
+	public User findUser(Long userId) {
+		UserJpaEntity userJpaEntity = userRepository.findById(userId).orElse(null);
+		if (ObjectUtils.isEmpty(userJpaEntity)) {
+			return null;
+		}
+		return userMapper.fromUserJpaEntity(userJpaEntity);
+	}
+}

--- a/member-service/src/main/java/com/freediving/memberservice/adapter/out/persistence/UserRepository.java
+++ b/member-service/src/main/java/com/freediving/memberservice/adapter/out/persistence/UserRepository.java
@@ -1,0 +1,12 @@
+package com.freediving.memberservice.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.freediving.memberservice.domain.OauthType;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserJpaEntity, Long> {
+
+	UserJpaEntity findByOauthTypeAndEmail(OauthType oauthType, String email);
+}

--- a/member-service/src/main/java/com/freediving/memberservice/application/port/in/CreateUserCommand.java
+++ b/member-service/src/main/java/com/freediving/memberservice/application/port/in/CreateUserCommand.java
@@ -1,0 +1,30 @@
+package com.freediving.memberservice.application.port.in;
+
+import com.freediving.common.SelfValidating;
+import com.freediving.memberservice.domain.OauthType;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Builder
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class CreateUserCommand extends SelfValidating<CreateUserCommand> {
+
+	private OauthType oauthType;
+
+	@NotNull
+	private final String email;
+
+	private final String profileImgUrl;
+
+	public CreateUserCommand(OauthType oauthType, String email, String profileImgUrl) {
+		this.oauthType = oauthType;
+		this.email = email;
+		this.profileImgUrl = profileImgUrl;
+		this.validateSelf();
+	}
+
+}

--- a/member-service/src/main/java/com/freediving/memberservice/application/port/in/CreateUserUseCase.java
+++ b/member-service/src/main/java/com/freediving/memberservice/application/port/in/CreateUserUseCase.java
@@ -1,0 +1,8 @@
+package com.freediving.memberservice.application.port.in;
+
+import com.freediving.common.config.annotation.UseCase;
+
+@UseCase
+public interface CreateUserUseCase {
+	void createUser(CreateUserCommand command);
+}

--- a/member-service/src/main/java/com/freediving/memberservice/application/port/in/FindUserCommand.java
+++ b/member-service/src/main/java/com/freediving/memberservice/application/port/in/FindUserCommand.java
@@ -1,0 +1,14 @@
+package com.freediving.memberservice.application.port.in;
+
+import com.freediving.common.SelfValidating;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@Builder
+@EqualsAndHashCode(callSuper = false)
+public class FindUserCommand extends SelfValidating<FindUserCommand> {
+	private final Long userId;
+}

--- a/member-service/src/main/java/com/freediving/memberservice/application/port/in/FindUserUseCase.java
+++ b/member-service/src/main/java/com/freediving/memberservice/application/port/in/FindUserUseCase.java
@@ -1,0 +1,7 @@
+package com.freediving.memberservice.application.port.in;
+
+import com.freediving.memberservice.domain.User;
+
+public interface FindUserUseCase {
+	User findUser(FindUserCommand findUserCommand);
+}

--- a/member-service/src/main/java/com/freediving/memberservice/application/port/out/CreateUserPort.java
+++ b/member-service/src/main/java/com/freediving/memberservice/application/port/out/CreateUserPort.java
@@ -1,0 +1,8 @@
+package com.freediving.memberservice.application.port.out;
+
+import com.freediving.memberservice.domain.OauthType;
+
+public interface CreateUserPort {
+
+	void createUser(OauthType oauthType, String email, String profileImgUrl);
+}

--- a/member-service/src/main/java/com/freediving/memberservice/application/port/out/FindUserPort.java
+++ b/member-service/src/main/java/com/freediving/memberservice/application/port/out/FindUserPort.java
@@ -1,0 +1,8 @@
+package com.freediving.memberservice.application.port.out;
+
+import com.freediving.memberservice.domain.User;
+
+public interface FindUserPort {
+
+	User findUser(Long userId);
+}

--- a/member-service/src/main/java/com/freediving/memberservice/application/service/CreateUserService.java
+++ b/member-service/src/main/java/com/freediving/memberservice/application/service/CreateUserService.java
@@ -1,0 +1,23 @@
+package com.freediving.memberservice.application.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.freediving.common.config.annotation.UseCase;
+import com.freediving.memberservice.application.port.in.CreateUserCommand;
+import com.freediving.memberservice.application.port.in.CreateUserUseCase;
+import com.freediving.memberservice.application.port.out.CreateUserPort;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class CreateUserService implements CreateUserUseCase {
+
+	private final CreateUserPort createUserPort;
+
+	@Override
+	public void createUser(CreateUserCommand command) {
+		createUserPort.createUser(command.getOauthType(), command.getEmail(), command.getProfileImgUrl());
+	}
+}

--- a/member-service/src/main/java/com/freediving/memberservice/application/service/FindUserService.java
+++ b/member-service/src/main/java/com/freediving/memberservice/application/service/FindUserService.java
@@ -1,0 +1,26 @@
+package com.freediving.memberservice.application.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.freediving.common.config.annotation.UseCase;
+import com.freediving.memberservice.application.port.in.FindUserCommand;
+import com.freediving.memberservice.application.port.in.FindUserUseCase;
+import com.freediving.memberservice.application.port.out.FindUserPort;
+import com.freediving.memberservice.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class FindUserService implements FindUserUseCase {
+
+	private final FindUserPort findUserPort;
+
+	@Override
+	public User findUser(FindUserCommand findUserCommand) {
+		User user = findUserPort.findUser(findUserCommand.getUserId());
+		// if (user == null)
+		return user;
+	}
+}

--- a/member-service/src/main/java/com/freediving/memberservice/domain/OauthType.java
+++ b/member-service/src/main/java/com/freediving/memberservice/domain/OauthType.java
@@ -1,0 +1,27 @@
+package com.freediving.memberservice.domain;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+public enum OauthType {
+	GOOGLE("GOOGLE"),
+	NAVER("NAVER"),
+	KAKAO("KAKAO");
+
+	private final String name;
+
+	OauthType(String name) {
+		this.name = name;
+	}
+
+	public static OauthType from(String type) {
+		return Arrays.stream(OauthType.values())
+			.filter(value -> value.getName().equals(type.toUpperCase()))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("지원하지 않는 소셜 로그인 타입입니다."));
+	}
+}

--- a/member-service/src/main/java/com/freediving/memberservice/domain/User.java
+++ b/member-service/src/main/java/com/freediving/memberservice/domain/User.java
@@ -1,0 +1,8 @@
+package com.freediving.memberservice.domain;
+
+public record User(Long userId, OauthType oauthType, String email, String profileImgUrl) {
+
+	public static User createUser(Long userId, OauthType oauthType, String email, String profileImgUrl) {
+		return new User(userId, oauthType, email, profileImgUrl);
+	}
+}


### PR DESCRIPTION
- MemberService 내 User 도메인 일부를 생성하였습니다. 
- 소셜로그인에서 사용되는 email, profileImgUrl만 우선적으로 적용하여 소셜로그인 회원가입이 가능하도록 구현하였습니다.