### PR TITLE
#66 - AWS PreSigned Url 생성 기능 개발

### DIFF
--- a/.github/workflows/member-service.yml
+++ b/.github/workflows/member-service.yml
@@ -2,7 +2,9 @@ name: CI & CD for member-service
 
 on:
   push:
-    branches: [ "feat/#41" ]
+    paths:
+      - 'member-service/**'
+    branches: [ "main" ]
 
 env:
   SERVICE_NAME: member-service

--- a/member-service/build.gradle
+++ b/member-service/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // aws - s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE'
 }
 
 jar {

--- a/member-service/src/main/java/com/freediving/authservice/adapter/in/web/ImgController.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/in/web/ImgController.java
@@ -1,0 +1,52 @@
+package com.freediving.authservice.adapter.in.web;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.freediving.authservice.adapter.in.web.dto.CreateImgRequest;
+import com.freediving.authservice.application.port.in.CreateImgCommand;
+import com.freediving.authservice.application.port.in.ImgUseCase;
+import com.freediving.common.config.annotation.WebAdapter;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @Author         : sasca37
+ * @Date           : 2024/01/21
+ * @Description    : 이미지 Presigned URL 정보를 생성하는 컨트롤러
+ * 					( AWS S3를 사용하지만, 추후 CloudFlare 전환 가능성 존재)
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ===========================================================
+ * 2024/01/21        sasca37       최초 생성
+ */
+
+@WebAdapter
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/img")
+@Slf4j
+@Tag(name = "Image", description = "이미지 Presigned URL 정보를 생성")
+public class ImgController {
+
+	private final ImgUseCase imgUseCase;
+
+	/**
+	 * @Author           : sasca37
+	 * @Date             : 2024/01/21
+	 * @Param            : PreSigned URL 생성을 위한 Request DTO
+	 * @Return           : PreSigned URL
+	 * @Description      : 이미지 정보를 전달받아 PreSigned URL 정보 반환
+	 */
+	@PostMapping
+	public String createPreSignedUrl(@RequestBody CreateImgRequest createImgRequest) {
+		CreateImgCommand createImgCommand = CreateImgCommand.builder()
+			.directory(createImgRequest.directory())
+			.build();
+		return imgUseCase.createPreSignedUrl(createImgCommand);
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/in/web/dto/CreateImgRequest.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/in/web/dto/CreateImgRequest.java
@@ -1,0 +1,22 @@
+package com.freediving.authservice.adapter.in.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * @Author         : sasca37
+ * @Date           : 2024/01/21
+ * @Description    : 이미지 PreSigned URL 정보를 요청하는 Request DTO
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ===========================================================
+ * 2024/01/21        sasca37       최초 생성
+ */
+
+@Schema(description = "이미지 PreSigned URL 요청 정보")
+public record CreateImgRequest(
+	@Schema(description = "이미지 저장 디렉토리명", example = "licence")
+	@NotNull(message = "디렉토리명은 필수 입니다.")
+	String directory
+) {
+}

--- a/member-service/src/main/java/com/freediving/authservice/adapter/out/external/aws/AwsImgExternalAdapter.java
+++ b/member-service/src/main/java/com/freediving/authservice/adapter/out/external/aws/AwsImgExternalAdapter.java
@@ -1,0 +1,69 @@
+package com.freediving.authservice.adapter.out.external.aws;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.freediving.authservice.application.port.in.ImgUtils;
+import com.freediving.authservice.application.port.out.ImgPort;
+import com.freediving.authservice.config.AwsConfigProperties;
+import com.freediving.common.config.annotation.ExternalSystemAdapter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @Author         : sasca37
+ * @Date           : 2024/01/21
+ * @Description    : AWS S3에 이미지 정보를 전송하는 Adapter
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ===========================================================
+ * 2024/01/21        sasca37       최초 생성
+ */
+
+@ExternalSystemAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class AwsImgExternalAdapter implements ImgPort {
+	private final AwsConfigProperties awsConfigProperties;
+	private final AmazonS3 amazonS3;
+
+	/**
+	 * @Author           : sasca37
+	 * @Date             : 2024/01/21
+	 * @Param            : 이미지 경로 ( 디렉토리/파일명)
+	 * @Return           : PreSigned URL 정보 반환
+	 * @Description      : AWS Configuration 에 등록한 시크릿 정보를 바탕으로 PreSigned URL 생성 및 URL 정보 반환
+	 */
+	@Override
+	public String generatePreSignedUrl(String imgPath) {
+		String bucket = awsConfigProperties.s3().bucket();
+
+		GeneratePresignedUrlRequest generatePresignedUrlRequest = getPreSignedUrl(bucket, imgPath);
+		return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+	}
+
+	/**
+	 * @Author           : sasca37
+	 * @Date             : 2024/01/21
+	 * @Param            : S3 버킷명, 파일명
+	 * @Return           : GeneratePresignedUrlRequest
+	 * @Description      : AWS S3 버킷에 이미지 업로드가 가능한 PreSigned URL 생성
+	 * 					 1. 클라이언트 요청 HTTP 메서드를 PUT으로 설정 및 URL 만료 시간 설정 (2분)
+	 * 					 2. 요청 헤더에 canned ACL(접근 제어 리스트)를 추가하여 업로드한 객체가 public read 권한을 갖도록 설정
+	 */
+	private GeneratePresignedUrlRequest getPreSignedUrl(String bucket, String uniqueImgName) {
+		GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, uniqueImgName)
+			.withMethod(HttpMethod.PUT)
+			.withExpiration(ImgUtils.getImgExpiration());
+		generatePresignedUrlRequest.addRequestParameter(
+			Headers.S3_CANNED_ACL,
+			CannedAccessControlList.PublicRead.toString()
+		);
+		return generatePresignedUrlRequest;
+	}
+}
+
+

--- a/member-service/src/main/java/com/freediving/authservice/application/port/in/CreateImgCommand.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/in/CreateImgCommand.java
@@ -1,0 +1,31 @@
+package com.freediving.authservice.application.port.in;
+
+import com.freediving.common.SelfValidating;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * @Author         : sasca37
+ * @Date           : 2024/01/21
+ * @Description    : CreateImgRequest 정보를 Command 객체로 전환 및 SelfValidation
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ===========================================================
+ * 2024/01/21        sasca37       최초 생성
+ */
+@Getter
+@Builder
+@EqualsAndHashCode(callSuper = false)
+public class CreateImgCommand extends SelfValidating<CreateImgCommand> {
+
+	@NotNull
+	private String directory;
+
+	public CreateImgCommand(String directory) {
+		this.directory = directory;
+		this.validateSelf();
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/in/ImgUseCase.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/in/ImgUseCase.java
@@ -1,0 +1,18 @@
+package com.freediving.authservice.application.port.in;
+
+import com.freediving.common.config.annotation.UseCase;
+
+/**
+ * @Author         : sasca37
+ * @Date           : 2024/01/21
+ * @Description    : Image PreSigned URL을 제공하는 UseCase
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ===========================================================
+ * 2024/01/21        sasca37       최초 생성
+ */
+
+@UseCase
+public interface ImgUseCase {
+	String createPreSignedUrl(CreateImgCommand createImgCommand);
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/in/ImgUtils.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/in/ImgUtils.java
@@ -1,0 +1,37 @@
+package com.freediving.authservice.application.port.in;
+
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * @Author         : sasca37
+ * @Date           : 2024/01/21
+ * @Description    : 이미지 정보를 관리하기 위한 Util
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ===========================================================
+ * 2024/01/21        sasca37       최초 생성
+ */
+public class ImgUtils {
+
+	private static final long EXPIRED_ACCESS_TIME = 2 * 60 * 1000L;
+
+	public static String createPath(String directory, String uniqueImgName) {
+		return String.format("%s/%s", directory, uniqueImgName);
+	}
+
+	public static Date getImgExpiration() {
+		return new Date(System.currentTimeMillis() + EXPIRED_ACCESS_TIME);
+	}
+
+	/**
+	 * @Author           : sasca37
+	 * @Date             : 2024/01/21
+	 * @Param            : 유저 식별 아이디
+	 * @Return           : 유저 식별 아이디-UUID로 조합된 파일명
+	 * @Description      : 유저 회원 탈퇴 등 일괄 이미지 관리를 위한 유저 아이디-UUID 조합으로 관리
+	 */
+	public static String createUniqueFileName(Long userId) {
+		return String.format("%s-%s", userId, UUID.randomUUID().toString().replace("-", ""));
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/port/out/ImgPort.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/port/out/ImgPort.java
@@ -1,0 +1,15 @@
+package com.freediving.authservice.application.port.out;
+
+/**
+ * @Author         : sasca37
+ * @Date           : 2024/01/21
+ * @Description    : 이미지 정보를 전달하기 위한 Port (AWS / CloudFlare)
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ===========================================================
+ * 2024/01/21        sasca37       최초 생성
+ */
+public interface ImgPort {
+
+	String generatePreSignedUrl(String imgPath);
+}

--- a/member-service/src/main/java/com/freediving/authservice/application/service/ImgService.java
+++ b/member-service/src/main/java/com/freediving/authservice/application/service/ImgService.java
@@ -1,0 +1,40 @@
+package com.freediving.authservice.application.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.freediving.authservice.application.port.in.CreateImgCommand;
+import com.freediving.authservice.application.port.in.ImgUseCase;
+import com.freediving.authservice.application.port.in.ImgUtils;
+import com.freediving.authservice.application.port.out.ImgPort;
+import com.freediving.common.config.annotation.UseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @Author         : sasca37
+ * @Date           : 2024/01/21
+ * @Description    : 이미지 생성 요청에 대한 PreSigned URL 정보를 전달하는 Service
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ===========================================================
+ * 2024/01/21        sasca37       최초 생성
+ */
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class ImgService implements ImgUseCase {
+
+	private final ImgPort imgPort;
+
+	@Override
+	public String createPreSignedUrl(CreateImgCommand createImgCommand) {
+		// TODO : 유저 식별 아이디 + UUID 조합으로 파일명 생성
+		Long userId = 1L;
+		String uniqueFileName = ImgUtils.createUniqueFileName(userId);
+		String imgPath = ImgUtils.createPath(createImgCommand.getDirectory(), uniqueFileName);
+		return imgPort.generatePreSignedUrl(imgPath);
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/config/AwsConfig.java
+++ b/member-service/src/main/java/com/freediving/authservice/config/AwsConfig.java
@@ -1,0 +1,45 @@
+package com.freediving.authservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @Author         : sasca37
+ * @Date           : 2024/01/21
+ * @Description    : AWS 관련 Credentials Configuration
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ===========================================================
+ * 2024/01/21        sasca37       최초 생성
+ */
+
+@Configuration
+@RequiredArgsConstructor
+public class AwsConfig {
+
+	private final AwsConfigProperties awsConfigProperties;
+
+	@Bean
+	@Primary
+	public BasicAWSCredentials credentialsProvider() {
+		AwsConfigProperties.Credentials credentials = awsConfigProperties.credentials();
+		return new BasicAWSCredentials(credentials.accessKey(), credentials.secretKey());
+	}
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		AmazonS3 s3Builder = AmazonS3ClientBuilder
+			.standard().withRegion(awsConfigProperties.region().info())
+			.withCredentials(new AWSStaticCredentialsProvider(credentialsProvider()))
+			.build();
+		return s3Builder;
+	}
+}

--- a/member-service/src/main/java/com/freediving/authservice/config/AwsConfigProperties.java
+++ b/member-service/src/main/java/com/freediving/authservice/config/AwsConfigProperties.java
@@ -1,0 +1,29 @@
+package com.freediving.authservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @Author         : sasca37
+ * @Date           : 2024/01/21
+ * @Description    : AWS Config 정보 바인딩
+ * ===========================================================
+ * DATE              AUTHOR             NOTE
+ * ===========================================================
+ * 2024/01/21        sasca37       최초 생성
+ */
+@ConfigurationProperties(prefix = "cloud.aws")
+public record AwsConfigProperties(
+	S3 s3,
+	Region region,
+	Credentials credentials
+) {
+	public record S3(String bucket) {
+	}
+
+	public record Credentials(String accessKey, String secretKey) {
+	}
+
+	public record Region(String info) {
+	}
+
+}

--- a/member-service/src/main/resources/application-local.yml
+++ b/member-service/src/main/resources/application-local.yml
@@ -74,3 +74,14 @@ oauth:
 
 jwt:
   key: ${JWT_KEY}
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    s3:
+      bucket: ${S3_BUCKET}
+    region:
+      static: ap-northeast-2
+      info: ap-northeast-2


### PR DESCRIPTION

## PreSigned URL 




![Image](https://github.com/freediving-community/api-server/assets/81945553/aca5ac5b-961e-454d-8ec9-a7d57a01407a)
- PreSigned URL 생성 요청 ( 클라이언트는 이미지 업로드 시 저장할 디렉토리 경로를 지정해서 요청한다)







![Image](https://github.com/freediving-community/api-server/assets/81945553/bfd3e046-73ba-4072-aaf9-999daa924b94)
- 발급 받은 PreSigned URL로 이미지를 담아 PUT 요청 (응답 값으로 이미지 URL 정보를 공유하지않고 성공 / 실패 여부만 반환하므로, 
클라이언트에서 PUT 요청한 URL에서 이미지 URL를 파싱한다.)


```
전체 경로 : https://buddyme-bucket.s3.ap-northeast-2.amazonaws.com/licence/1-4ec88f9f9eed46ee9d50fab5c3e7bead?x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240121T095426Z&X-Amz-SignedHeaders=host&X-Amz-Expires=119&X-Amz-Credential=AKIA252KLZKE2HVWKSEP%2F20240121%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=97a2d083673420a6e12afb37ec0421c25fa2040824293026a7e626b4f2f69272

파싱할 경로 : https://buddyme-bucket.s3.ap-northeast-2.amazonaws.com/licence/1-4ec88f9f9eed46ee9d50fab5c3e7bead
```

## S3 저장 확인

![Image](https://github.com/freediving-community/api-server/assets/81945553/b8e94668-0c3f-4d39-8090-c0f6085730ba)

- S3 이미지 업로드 결과 (유저 식별 아이디 | UUID 조합)







![Image](https://github.com/freediving-community/api-server/assets/81945553/0dc87faa-9591-48ae-8ff9-2c0b1ceb8969)
- 실패 결과 (요청 가능 시간이 만료되었을 때 - 2분) 
