### PR TITLE
Feat/#76 - API 응답 규격, 예외 핸들러 개발

### DIFF
--- a/buddy-service/build.gradle
+++ b/buddy-service/build.gradle
@@ -19,7 +19,6 @@ dependencyManagement {
 dependencies {
     implementation project(':common')
 
-    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/buddy-service/build.gradle
+++ b/buddy-service/build.gradle
@@ -18,7 +18,7 @@ dependencyManagement {
 
 dependencies {
     implementation project(':common')
-
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/buddy-service/src/main/java/com/freediving/buddyservice/adapter/in/web/v1/CreateBuddyEventControllerV1.java
+++ b/buddy-service/src/main/java/com/freediving/buddyservice/adapter/in/web/v1/CreateBuddyEventControllerV1.java
@@ -16,8 +16,6 @@ import com.freediving.common.response.ResponseJsonObject;
 import com.freediving.common.response.enumerate.ServiceStatusCode;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -47,23 +45,17 @@ public class CreateBuddyEventControllerV1 {
 			@ApiResponse(
 				responseCode = "200",
 				description = "버디 이벤트 생성 성공",
-				content = @Content(mediaType = "application/json",
-					schema = @Schema(implementation = CreatedBuddyEvent.class))
+				useReturnTypeSchema = true
 			),
-			@ApiResponse(
-				responseCode = "400",
-				description = "잘못된 요청",
-				content = @Content(mediaType = "application/json")
-			),
-			@ApiResponse(
-				responseCode = "401",
-				description = "인증되지 않은 사용자",
-				content = @Content(mediaType = "application/json")
-			)
+			@ApiResponse(responseCode = "400", ref = "#/components/responses/400"),
+			@ApiResponse(responseCode = "401", ref = "#/components/responses/401"),
+			@ApiResponse(responseCode = "403", ref = "#/components/responses/403"),
+			@ApiResponse(responseCode = "500", ref = "#/components/responses/500")
 		}
 	)
 	@PostMapping("")
-	public ResponseEntity<ResponseJsonObject> createBuddyEvent(@Valid @RequestBody CreateBuddyEventRequestV1 request) {
+	public ResponseEntity<ResponseJsonObject<CreatedBuddyEvent>> createBuddyEvent(
+		@Valid @RequestBody CreateBuddyEventRequestV1 request) {
 		// 1. JWT 유저 토큰에서 사용자 식별 ID 가져오기
 		Random random = new Random();
 		Long userId = random.nextLong();
@@ -81,10 +73,8 @@ public class CreateBuddyEventControllerV1 {
 				.build());
 
 		// 3. Command 요청 및 응답 리턴.
-		ResponseJsonObject response = ResponseJsonObject.builder()
-			.code(ServiceStatusCode.OK)
-			.data(createdBuddyEvent)
-			.build();
+		ResponseJsonObject<CreatedBuddyEvent> response = new ResponseJsonObject<>(ServiceStatusCode.OK,
+			createdBuddyEvent);
 
 		return ResponseEntity.ok(response);
 	}

--- a/buddy-service/src/main/java/com/freediving/buddyservice/adapter/in/web/v1/CreateBuddyEventControllerV1.java
+++ b/buddy-service/src/main/java/com/freediving/buddyservice/adapter/in/web/v1/CreateBuddyEventControllerV1.java
@@ -12,6 +12,8 @@ import com.freediving.buddyservice.application.port.in.CreateBuddyEventCommand;
 import com.freediving.buddyservice.application.port.in.CreateBuddyEventUseCase;
 import com.freediving.buddyservice.domain.CreatedBuddyEvent;
 import com.freediving.common.config.annotation.WebAdapter;
+import com.freediving.common.response.ResponseJsonObject;
+import com.freediving.common.response.enumerate.ServiceStatusCode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -61,7 +63,7 @@ public class CreateBuddyEventControllerV1 {
 		}
 	)
 	@PostMapping("")
-	public ResponseEntity<CreatedBuddyEvent> createBuddyEvent(@Valid @RequestBody CreateBuddyEventRequestV1 request) {
+	public ResponseEntity<ResponseJsonObject> createBuddyEvent(@Valid @RequestBody CreateBuddyEventRequestV1 request) {
 		// 1. JWT 유저 토큰에서 사용자 식별 ID 가져오기
 		Random random = new Random();
 		Long userId = random.nextLong();
@@ -79,6 +81,11 @@ public class CreateBuddyEventControllerV1 {
 				.build());
 
 		// 3. Command 요청 및 응답 리턴.
-		return ResponseEntity.ok(createdBuddyEvent);
+		ResponseJsonObject response = ResponseJsonObject.builder()
+			.code(ServiceStatusCode.OK)
+			.data(createdBuddyEvent)
+			.build();
+
+		return ResponseEntity.ok(response);
 	}
 }

--- a/buddy-service/src/main/java/com/freediving/buddyservice/config/SwaggerConfig.java
+++ b/buddy-service/src/main/java/com/freediving/buddyservice/config/SwaggerConfig.java
@@ -6,9 +6,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.freediving.common.response.ResponseJsonObject;
+import com.freediving.common.response.enumerate.ServiceStatusCode;
+
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
@@ -38,8 +44,24 @@ public class SwaggerConfig {
 			.addList("bearerAuth");
 
 		return new OpenAPI().addServersItem(new Server().url(url).description(description))
-			.components(new Components().addSecuritySchemes("Access Token", securityScheme))
+			.components(
+				new Components().addSecuritySchemes("Access Token", securityScheme)
+					.addResponses("400", new ApiResponse().description("Bad Request").content(new Content()
+						.addMediaType("application/json", new MediaType()
+								.example(
+									ResponseJsonObject.builder()
+										.code(ServiceStatusCode.BAD_REQUEST)
+										.expandMsg("expandMsg")
+										.build())
+							// 예시 값
+						)))
+					.addResponses("401", new ApiResponse().description("Unauthorized"))
+					.addResponses("403", new ApiResponse().description("Forbidden"))
+					.addResponses("500", new ApiResponse().description("Internal Server Error"))
+			)
 			.security(List.of(securityRequirement))
 			.info(new Info().title(title).version(version));
+
 	}
+
 }

--- a/buddy-service/src/main/java/com/freediving/buddyservice/domain/CreatedBuddyEvent.java
+++ b/buddy-service/src/main/java/com/freediving/buddyservice/domain/CreatedBuddyEvent.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 @Builder
 @Getter
 
-@Schema(title = "버디 이벤트 생성 결과 ( CreatedBuddyEvent )", description = "POST /v1/event 버디 이벤트 생성 결과")
+@Schema(title = "버디 이벤트 생성 결과 ( CreatedBuddyEvent )", description = "POST /v1/event 버디 이벤트 생성 결과", hidden = true)
 public class CreatedBuddyEvent {
 
 	@Schema(description = "이벤트 ID", example = "12345")

--- a/buddy-service/src/main/resources/application-local.yml
+++ b/buddy-service/src/main/resources/application-local.yml
@@ -4,8 +4,6 @@ server:
 spring:
   application:
     name: buddy-service
-  jackson:
-    date-format: "yyyy-MM-dd HH:mm:ss.SSS"
   # Only for Local Test
   # H2
   h2:
@@ -42,4 +40,3 @@ swagger:
     version: "V1"
     url: http://localhost:8000/${spring.application.name}
     description: Local Gateway Server
-

--- a/buddy-service/src/test/java/com/freediving/buddyservice/adapter/in/web/v1/CreateBuddyEventControllerV1Test.java
+++ b/buddy-service/src/test/java/com/freediving/buddyservice/adapter/in/web/v1/CreateBuddyEventControllerV1Test.java
@@ -21,13 +21,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.freediving.buddyservice.application.port.in.CreateBuddyEventCommand;
 import com.freediving.buddyservice.application.port.in.CreateBuddyEventUseCase;
 import com.freediving.buddyservice.application.port.out.service.RequestMemberPort;
+import com.freediving.buddyservice.common.ControllerDefendenciesConfig;
 import com.freediving.buddyservice.common.enumeration.EventConcept;
 import com.freediving.buddyservice.common.enumeration.EventStatus;
 import com.freediving.buddyservice.domain.CreatedBuddyEvent;
 
 @WebMvcTest(controllers = CreateBuddyEventControllerV1.class)
 @ActiveProfiles("local")
-class CreateBuddyEventControllerV1Test {
+class CreateBuddyEventControllerV1Test extends ControllerDefendenciesConfig {
 
 	@MockBean
 	private CreateBuddyEventUseCase createBuddyEventUseCase;
@@ -93,6 +94,50 @@ class CreateBuddyEventControllerV1Test {
 			.andExpect(MockMvcResultMatchers.jsonPath("$.data.createdDate").value("2024-01-01T09:00:00"))
 			.andExpect(MockMvcResultMatchers.jsonPath("$.data.updatedDate").value("2024-01-01T09:00:00"))
 			.andExpect(MockMvcResultMatchers.jsonPath("$.msg").isEmpty());
+	}
+
+	@DisplayName("일정 시작 시간 필수 값 체크")
+	@Test
+	void eventStartTimeIsRequired() throws Exception {
+		//given
+		final CreateBuddyEventRequestV1 request = CreateBuddyEventRequestV1.builder()
+			.eventEndDate(LocalDateTime.now().plusHours(8))
+			.participantCount(11)
+			.eventConcepts(List.of(EventConcept.LEVEL_UP))
+			.carShareYn(false)
+			.comment("ㅋㅋㅋㅋ")
+			.build();
+
+		//when then
+		mockMvc.perform(MockMvcRequestBuilders.post("/v1/event")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(MockMvcResultHandlers.print())
+			.andExpect(MockMvcResultMatchers.status().isBadRequest())
+			.andExpect(MockMvcResultMatchers.jsonPath("$.code").value(400))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.msg").value("BAD_REQUEST(일정 시작 시간은 필수입니다.)"));
+	}
+
+	@DisplayName("일정 종료 시간 필수 값 체크")
+	@Test
+	void eventEndTimeIsRequired() throws Exception {
+		//given
+		final CreateBuddyEventRequestV1 request = CreateBuddyEventRequestV1.builder()
+			.eventStartDate(LocalDateTime.now().plusHours(8))
+			.participantCount(11)
+			.eventConcepts(List.of(EventConcept.LEVEL_UP))
+			.carShareYn(false)
+			.comment("ㅋㅋㅋㅋ")
+			.build();
+
+		//when then
+		mockMvc.perform(MockMvcRequestBuilders.post("/v1/event")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(MockMvcResultHandlers.print())
+			.andExpect(MockMvcResultMatchers.status().isBadRequest())
+			.andExpect(MockMvcResultMatchers.jsonPath("$.code").value(400))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.msg").value("BAD_REQUEST(일정 종료 시간은 필수입니다.)"));
 	}
 
 }

--- a/buddy-service/src/test/java/com/freediving/buddyservice/adapter/in/web/v1/CreateBuddyEventControllerV1Test.java
+++ b/buddy-service/src/test/java/com/freediving/buddyservice/adapter/in/web/v1/CreateBuddyEventControllerV1Test.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -21,9 +22,11 @@ import com.freediving.buddyservice.application.port.in.CreateBuddyEventCommand;
 import com.freediving.buddyservice.application.port.in.CreateBuddyEventUseCase;
 import com.freediving.buddyservice.application.port.out.service.RequestMemberPort;
 import com.freediving.buddyservice.common.enumeration.EventConcept;
+import com.freediving.buddyservice.common.enumeration.EventStatus;
 import com.freediving.buddyservice.domain.CreatedBuddyEvent;
 
 @WebMvcTest(controllers = CreateBuddyEventControllerV1.class)
+@ActiveProfiles("local")
 class CreateBuddyEventControllerV1Test {
 
 	@MockBean
@@ -45,14 +48,15 @@ class CreateBuddyEventControllerV1Test {
 			.thenReturn(CreatedBuddyEvent.builder()
 				.eventId(1L)
 				.userId(1L)
-				.eventStartDate(LocalDateTime.now().plusHours(4))
-				.eventEndDate(LocalDateTime.now().plusHours(11))
+				.eventStartDate(LocalDateTime.of(2024, 01, 01, 10, 00, 00))
+				.eventEndDate(LocalDateTime.of(2024, 01, 01, 14, 00, 00))
 				.participantCount(11)
 				.eventConcepts(List.of(EventConcept.LEVEL_UP))
+				.status(EventStatus.RECRUITING)
 				.carShareYn(false)
-				.comment("")
-				.createdDate(LocalDateTime.now())
-				.updatedDate(LocalDateTime.now())
+				.comment("ㅋㅋㅋㅋ")
+				.createdDate(LocalDateTime.of(2024, 01, 01, 9, 00, 00))
+				.updatedDate(LocalDateTime.of(2024, 01, 01, 9, 00, 00))
 				.build());
 
 	}
@@ -61,7 +65,7 @@ class CreateBuddyEventControllerV1Test {
 	@Test
 	void shouldCreateNewBuddyEventSuccessfully() throws Exception {
 		//given
-		CreateBuddyEventRequestV1 request = CreateBuddyEventRequestV1.builder()
+		final CreateBuddyEventRequestV1 request = CreateBuddyEventRequestV1.builder()
 			.eventStartDate(LocalDateTime.now().plusHours(2))
 			.eventEndDate(LocalDateTime.now().plusHours(8))
 			.participantCount(11)
@@ -71,13 +75,24 @@ class CreateBuddyEventControllerV1Test {
 			.build();
 
 		//when then
-		mockMvc.perform(MockMvcRequestBuilders.post("/v1/event/")
+		mockMvc.perform(MockMvcRequestBuilders.post("/v1/event")
 				.content(objectMapper.writeValueAsString(request))
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(MockMvcResultHandlers.print())
-			.andExpect(MockMvcResultMatchers.status().isOk());
-		// TODO : 응답 규격 정해지면 응답 규격 검사 추가 필요.
-
+			.andExpect(MockMvcResultMatchers.status().isOk())
+			.andExpect(MockMvcResultMatchers.jsonPath("$.code").value(200))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.eventId").value(1))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.userId").value(1))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.eventStartDate").value("2024-01-01T10:00:00"))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.eventEndDate").value("2024-01-01T14:00:00"))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.participantCount").value(11))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.eventConcepts[0]").value("LEVEL_UP"))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.carShareYn").value(false))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.status").value(EventStatus.RECRUITING.name()))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.comment").value("ㅋㅋㅋㅋ"))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.createdDate").value("2024-01-01T09:00:00"))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.updatedDate").value("2024-01-01T09:00:00"))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.msg").isEmpty());
 	}
 
 }

--- a/buddy-service/src/test/java/com/freediving/buddyservice/common/ControllerDefendenciesConfig.java
+++ b/buddy-service/src/test/java/com/freediving/buddyservice/common/ControllerDefendenciesConfig.java
@@ -1,0 +1,9 @@
+package com.freediving.buddyservice.common;
+
+import org.springframework.context.annotation.Import;
+
+import com.freediving.common.handler.exception.ServiceExceptionHandler;
+
+@Import(ServiceExceptionHandler.class)
+public class ControllerDefendenciesConfig {
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,10 +10,13 @@ repositories {
 }
 
 dependencies {
-    testImplementation platform('org.junit:junit-bom:5.9.1')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    testImplementation platform('org.junit:junit-bom:5.9.1')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+
 }
 
 test {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/common/src/main/java/com/freediving/common/handler/exception/BuddyMeException.java
+++ b/common/src/main/java/com/freediving/common/handler/exception/BuddyMeException.java
@@ -1,0 +1,25 @@
+package com.freediving.common.handler.exception;
+
+import com.freediving.common.response.ResponseJsonObject;
+import com.freediving.common.response.enumerate.ServiceStatusCode;
+
+public class BuddyMeException extends RuntimeException {
+
+	private final ServiceStatusCode serviceStatusCode;
+	private final ResponseJsonObject responseJsonObject;
+
+	public ResponseJsonObject getResponseJsonObject() {
+		return responseJsonObject;
+	}
+
+	public BuddyMeException(ServiceStatusCode apiStatusCode) {
+		this.serviceStatusCode = apiStatusCode;
+		responseJsonObject = ResponseJsonObject.builder().code(serviceStatusCode).build();
+	}
+
+	public BuddyMeException(ServiceStatusCode apiStatusCode, String msg) {
+		super(msg);
+		this.serviceStatusCode = apiStatusCode;
+		responseJsonObject = ResponseJsonObject.builder().code(serviceStatusCode).expandMsg(msg).build();
+	}
+}

--- a/common/src/main/java/com/freediving/common/handler/exception/ServiceExceptionHandler.java
+++ b/common/src/main/java/com/freediving/common/handler/exception/ServiceExceptionHandler.java
@@ -15,6 +15,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import com.freediving.common.response.ResponseJsonObject;
 import com.freediving.common.response.enumerate.ServiceStatusCode;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.log4j.Log4j2;
 
@@ -35,6 +37,13 @@ public class ServiceExceptionHandler extends ResponseEntityExceptionHandler {
 	 * @param ex Exception
 	 * @return desc
 	 */
+	@ApiResponse(
+		responseCode = "500",
+		description = "시스템 에러",
+		content = @Content(
+			mediaType = "application/json"
+		)
+	)
 	@ExceptionHandler(RuntimeException.class)
 	public ResponseEntity<ResponseJsonObject> handleException(RuntimeException ex) {
 		log.error("RuntimeExceptionHandler : {} \n StackTrace : ", ex.getMessage(), ex.getStackTrace());

--- a/common/src/main/java/com/freediving/common/handler/exception/ServiceExceptionHandler.java
+++ b/common/src/main/java/com/freediving/common/handler/exception/ServiceExceptionHandler.java
@@ -1,0 +1,108 @@
+package com.freediving.common.handler.exception;
+
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.freediving.common.response.ResponseJsonObject;
+import com.freediving.common.response.enumerate.ServiceStatusCode;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * 버디미 서비스 RestController에서 발생하는 API Exception을 핸들링 한다.
+ *
+ * @author 준희조
+ * @version 1.0.0
+ * 작성일 2024-01-29
+ **/
+@Log4j2
+@RestControllerAdvice(basePackages = "com.freediving")
+public class ServiceExceptionHandler extends ResponseEntityExceptionHandler {
+
+	/**
+	 * RuntimeException 핸들링.
+	 *
+	 * @param ex Exception
+	 * @return desc
+	 */
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ResponseJsonObject> handleException(RuntimeException ex) {
+		log.error("RuntimeExceptionHandler : {} \n StackTrace : ", ex.getMessage(), ex.getStackTrace());
+
+		return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	/**
+	 * Bean Validation API 사용하여 @Valid, @Validated 어노테이션 사용시 파라미터 유효성 검증 실패시 발생하는
+	 * ConstraintViolationException 대해서 핸들링 한다.
+	 *
+	 * @param ex ConstraintViolationException
+	 * @return desc
+	 */
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ResponseJsonObject> handleConstraintViolationException(ConstraintViolationException ex) {
+		log.error("파라미터 유효성 체크 실패. : {} \n StackTrace : ", ex.getMessage(), ex.getStackTrace());
+
+		ResponseJsonObject response;
+
+		if (ex.getConstraintViolations().isEmpty() == false) {
+			String exceptionMsg = ex.getConstraintViolations().stream()
+				.map(v1 -> v1.getMessage())
+				.collect(Collectors.joining(","));
+			response = ResponseJsonObject.builder()
+				.code(ServiceStatusCode.BAD_REQUEST)
+				.expandMsg(exceptionMsg)
+				.build();
+		} else
+			response = ResponseJsonObject.builder().code(ServiceStatusCode.BAD_REQUEST).build();
+
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	/**
+	 * @RequestBody의 매핑 실패일경우  MethodArgumentNotValidException 예외 에러가 발생한다.
+	 *
+	 * @param ex MethodArgumentNotValidException
+	 * @return desc
+	 */
+	@Override
+	protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+		HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+		log.error("파라미터 유효성 체크 실패. : {} \n StackTrace : ", ex.getMessage(), ex.getStackTrace());
+		ResponseJsonObject response;
+
+		if (ex.getBindingResult().hasErrors())
+			response = ResponseJsonObject.builder().code(ServiceStatusCode.BAD_REQUEST)
+				.expandMsg(ex.getBindingResult().getFieldError().getDefaultMessage()).build();
+		else
+			response = ResponseJsonObject.builder().code(ServiceStatusCode.BAD_REQUEST).build();
+
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler({BuddyMeException.class})
+	public ResponseEntity<ResponseJsonObject> handleDikeServiceException(BuddyMeException ex) {
+		log.debug("DikeServiceExceptionHandler : {}", ex.getResponseJsonObject().toString());
+		HttpStatus exceptionStatus = HttpStatus.OK;
+
+		switch (ex.getResponseJsonObject().getCode()) {
+			case 400:
+				exceptionStatus = HttpStatus.BAD_REQUEST;
+				break;
+			default:
+				exceptionStatus = HttpStatus.OK;
+		}
+
+		return new ResponseEntity<>(ex.getResponseJsonObject(), exceptionStatus);
+	}
+}

--- a/common/src/main/java/com/freediving/common/response/ResponseJsonObject.java
+++ b/common/src/main/java/com/freediving/common/response/ResponseJsonObject.java
@@ -16,13 +16,24 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @AllArgsConstructor
-public class ResponseJsonObject {
+public class ResponseJsonObject<T> {
 
 	@Builder.Default
 	private ServiceStatusCode code = ServiceStatusCode.OK;
 	@Builder.Default
 	private String expandMsg = null;
-	private Object data;
+	private T data;
+
+	public ResponseJsonObject(ServiceStatusCode serviceStatusCode, T data) {
+		this.code = serviceStatusCode;
+		this.data = data;
+	}
+
+	public ResponseJsonObject(ServiceStatusCode serviceStatusCode, T data, String expandMsg) {
+		this.code = serviceStatusCode;
+		this.data = data;
+		this.expandMsg = expandMsg;
+	}
 
 	// --------------- JSON 필드 --------------------
 	public int getCode() {
@@ -31,19 +42,19 @@ public class ResponseJsonObject {
 
 	public String getMsg() {
 		// 추가 메시지가 있는 경우
-		if (expandMsg != null)
-			return String.format("%s(%s)", this.code.getMessage(), expandMsg);
+		if (this.expandMsg != null)
+			return String.format("%s(%s)", this.code.getMessage(), this.expandMsg);
 
 		return this.code.getMessage();
 	}
 
 	// data
-	public Object getData() {
-		return data;
+	public T getData() {
+		return this.data;
 	}
 	// ---------------------------------------------
 
 	public Boolean errorType() {
-		return code.getIsErrorType();
+		return this.code.getIsErrorType();
 	}
 }

--- a/common/src/main/java/com/freediving/common/response/ResponseJsonObject.java
+++ b/common/src/main/java/com/freediving/common/response/ResponseJsonObject.java
@@ -32,7 +32,7 @@ public class ResponseJsonObject {
 	public String getMsg() {
 		// 추가 메시지가 있는 경우
 		if (expandMsg != null)
-			return String.format("{0}({1)", this.code.getMessage(), expandMsg);
+			return String.format("%s(%s)", this.code.getMessage(), expandMsg);
 
 		return this.code.getMessage();
 	}

--- a/common/src/main/java/com/freediving/common/response/ResponseJsonObject.java
+++ b/common/src/main/java/com/freediving/common/response/ResponseJsonObject.java
@@ -1,0 +1,49 @@
+package com.freediving.common.response;
+
+import com.freediving.common.response.enumerate.ServiceStatusCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+/**
+ * 버디미 서비스 API의 공통 응답 규격.
+ *
+ * @author 준희조
+ * @version 1.0.0
+ * 작성일 2024-01-26
+ **/
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class ResponseJsonObject {
+
+	@Builder.Default
+	private ServiceStatusCode code = ServiceStatusCode.OK;
+	@Builder.Default
+	private String expandMsg = null;
+	private Object data;
+
+	// --------------- JSON 필드 --------------------
+	public int getCode() {
+		return this.code.getCode();
+	}
+
+	public String getMsg() {
+		// 추가 메시지가 있는 경우
+		if (expandMsg != null)
+			return String.format("{0}({1)", this.code.getMessage(), expandMsg);
+
+		return this.code.getMessage();
+	}
+
+	// data
+	public Object getData() {
+		return data;
+	}
+	// ---------------------------------------------
+
+	public Boolean errorType() {
+		return code.getIsErrorType();
+	}
+}

--- a/common/src/main/java/com/freediving/common/response/enumerate/ServiceStatusCode.java
+++ b/common/src/main/java/com/freediving/common/response/enumerate/ServiceStatusCode.java
@@ -19,7 +19,7 @@ import lombok.Getter;
 @Getter
 public enum ServiceStatusCode {
 
-	OK(200, null, false)
+	OK(200, null, false), BAD_REQUEST(400, "BAD_REQUEST", false)
 
 	// member-service
 	, MEMBER_SERVICE(0, "멤버 서비스 응답 메시지.", false)

--- a/common/src/main/java/com/freediving/common/response/enumerate/ServiceStatusCode.java
+++ b/common/src/main/java/com/freediving/common/response/enumerate/ServiceStatusCode.java
@@ -1,0 +1,43 @@
+package com.freediving.common.response.enumerate;
+
+import lombok.Getter;
+
+/**
+ * 모든 API에서 사용될 API 처리 상태 코드관리 Enum Class
+ *  ServiceStatusCode는 HttpStatus가 200인 경우 반환되는 서비스 처리 결과이다.
+ *  Http 통신이 200으로 성공했으며, HttpStatus로 표현 불가한 서비스 응답 코드를 내려주기 위함.
+ *
+ *  버디미 비즈니스 응답 규격 ( 표준 Http 상태코드로 표현 불가능한 비즈니스 코드 )
+ *  	- 12XX 코드 : 멤버 관련 서비스 코드
+ *  	- 13XX 코드 : 커뮤니티 관련 서비스 코드
+ *  	- 14XX 코드 : 버디 이벤트 관련 서비스 코드
+ *
+ * @author 준희조
+ * @version 1.0.0
+ * 작성일 2024-01-26
+ **/
+@Getter
+public enum ServiceStatusCode {
+
+	OK(200, null, false)
+
+	// member-service
+	, MEMBER_SERVICE(0, "멤버 서비스 응답 메시지.", false)
+
+	// community-service
+	, COMMUNITY_SERVICE(0, "커뮤니티 서비스 응답 메시지.", false)
+
+	// buddy-service
+	, BUDDY_SERVICE(0, "버디 서비스 응답 메시지.", false);
+
+	//Enum 필드
+	private int code;
+	private String message;
+	private Boolean isErrorType;     // 서비스 비즈니스 Error 타입.
+
+	ServiceStatusCode(int code, String message, Boolean isErrorType) {
+		this.code = code;
+		this.message = message;
+		this.isErrorType = isErrorType;
+	}
+}


### PR DESCRIPTION
### 추가 관련 리소스
com.freediving.common.handler.exception.BuddyMeException.java
com.freediving.common.handler.exception.ServiceExceptionHandler.java
com.freediving.common.response.enumerate.ServiceStatusCode.java
com.freediving.common.response.ResponseJsonObject.java

### 응답 규격 type 삭제.
```java
{
  "meta" : {
             "code" : 1214,
             "message" : "설정하려는 닉네임이 중복된 닉네임 입니다"
             // "type" : "Duplicate Name" 삭제.
  },
  "data" : {
             "key": "value" ....
  }
}
```

### Controller 사용 예제
Swagger ApiResponse 제공을 위해 제너럴<T> 타입의 리턴 반환을 추천 드립니다.
응답은 ResponseEntiry객체에 ResponseJsonObject 담아 응답하는게 핵심입니다.

```java
@Operation(
summary = "버디 이벤트 생성하기",
description = "새로운 버디 이벤트를 생성합니다.",
responses = {
	@ApiResponse(
		responseCode = "200",
		description = "버디 이벤트 생성 성공",
		useReturnTypeSchema = true
	)
}
)
@PostMapping("")
public ResponseEntity<ResponseJsonObject<CreatedBuddyEvent>> createBuddyEvent(
@Valid @RequestBody CreateBuddyEventRequestV1 request) {
// 1. JWT 유저 토큰에서 사용자 식별 ID 가져오기
Random random = new Random();
Long userId = random.nextLong();

// 2. Use Case Command 전달.
CreatedBuddyEvent createdBuddyEvent = createBuddyEventUseCase.createBuddyEventV1(
	CreateBuddyEventCommand.builder()
		.userId(userId)
		.eventStartDate(request.getEventStartDate())
		.eventEndDate(request.getEventEndDate())
		.participantCount(request.getParticipantCount())
		.eventConcepts(request.getEventConcepts())
		.carShareYn(request.getCarShareYn())
		.comment(request.getComment())
		.build());

// 3. Command 요청 및 응답 리턴.
ResponseJsonObject<CreatedBuddyEvent> response = new ResponseJsonObject<>(ServiceStatusCode.OK,
	createdBuddyEvent);

return ResponseEntity.ok(response);
}
```


### BuddyMeException

BuddyMeException 객체는 버디미 서비스간의 비즈니스 예외를 발생합니다. 
e.g 비즈니스 도메인 정책 기준 버디 모집은 최대 5개만 되는 정책보다 더 많은 모집을 생성하는 경우 발생하는 비즈니스 예외.

```java
@PostMapping("")
public ResponseEntity<ResponseJsonObject<CreatedBuddyEvent>> createBuddyEvent(
@Valid @RequestBody CreateBuddyEventRequestV1 request) {
// 1. JWT 유저 토큰에서 사용자 식별 ID 가져오기
Random random = new Random();
Long userId = random.nextLong();

// 2. Use Case Command 전달.
CreatedBuddyEvent createdBuddyEvent = createBuddyEventUseCase.createBuddyEventV1(
	CreateBuddyEventCommand.builder()
		.userId(userId)
		.eventStartDate(request.getEventStartDate())
		.eventEndDate(request.getEventEndDate())
		.participantCount(request.getParticipantCount())
		.eventConcepts(request.getEventConcepts())
		.carShareYn(request.getCarShareYn())
		.comment(request.getComment())
		.build());

if(createdBuddyEvent .getCount() > 5) 
	throw new BuddyMeException(ServiceStatusCode.BUDDY_SERVICE);
//	throw new BuddyMeException(ServiceStatusCode.BUDDY_SERVICE," 추가적인 메시지", ;  // 추가 메시지가 포함된 예외

// 3. Command 요청 및 응답 리턴.
ResponseJsonObject<CreatedBuddyEvent> response = new ResponseJsonObject<>(ServiceStatusCode.OK,
	createdBuddyEvent);

return ResponseEntity.ok(response);
}

```
발생한 BuddyMeException는 ServiceExceptionHandler객체에서 핸들링 하고 있습니다.
BuddyMeException는 HttpStatusCode가 200으로 응답됩니다.

### 고려사항
컨트롤러 테스트 코드 작성 시 @.Import(ServiceExceptionHandler.class) 고려하기.



