### PR TITLE
refactor: #162 - 유저 정보 수정 시 카프카 예외 처리 및 조회 데이터 추가

### DIFF
--- a/member-service/src/main/java/com/freediving/memberservice/adapter/out/kafka/UserPreferencesProducer.java
+++ b/member-service/src/main/java/com/freediving/memberservice/adapter/out/kafka/UserPreferencesProducer.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.kafka.core.KafkaTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.freediving.common.handler.exception.BuddyMeException;
+import com.freediving.common.response.enumerate.ServiceStatusCode;
 import com.freediving.memberservice.adapter.out.dto.UserConceptRequest;
 import com.freediving.memberservice.adapter.out.dto.UserPoolRequest;
 
@@ -42,6 +44,7 @@ public class UserPreferencesProducer {
 			this.kafkaTemplate.send(poolTopic, objectMapper.writeValueAsString(userPoolRequest));
 		} catch (Exception e) {
 			log.error("ERROR [Produce sendUserPool] userId : {}, error : ", userPoolRequest.getUserId(), e);
+			throw new BuddyMeException(ServiceStatusCode.INTERVAL_SERVER_ERROR, "userPoolRequest 카프카 Producing 중 오류 발생");
 		}
 	}
 
@@ -52,6 +55,7 @@ public class UserPreferencesProducer {
 			this.kafkaTemplate.send(conceptTopic, objectMapper.writeValueAsString(userConceptRequest));
 		} catch (Exception e) {
 			log.error("ERROR [Produce sendUserPool] userId : {}, error : ", userConceptRequest.getUserId(), e);
+			throw new BuddyMeException(ServiceStatusCode.INTERVAL_SERVER_ERROR, "userConceptRequest 카프카 Producing 중 오류 발생");
 		}
 	}
 }

--- a/member-service/src/main/java/com/freediving/memberservice/adapter/out/persistence/UpdateUserPersistenceAdapter.java
+++ b/member-service/src/main/java/com/freediving/memberservice/adapter/out/persistence/UpdateUserPersistenceAdapter.java
@@ -53,7 +53,7 @@ public class UpdateUserPersistenceAdapter implements UpdateUserPort {
 		updateUserInfo(command, userJpaEntity);
 		updateUserPreferences(userId, poolList, conceptList);
 
-		User user = User.fromJpaEntityList(userJpaEntity, userLicenseJpaEntityList);
+		User user = User.fromJpaEntityListAndInternalInfo(userJpaEntity, userLicenseJpaEntityList,conceptList, poolList);
 		return FindUserResponse.from(user);
 	}
 


### PR DESCRIPTION
- 유저 선호 데이터 실패 시 예외 반환하고, 성공 시 해당 선호 데이터 조회 데이터로 반환